### PR TITLE
Fill up a random zone

### DIFF
--- a/07_zns/test_zns.py
+++ b/07_zns/test_zns.py
@@ -45,22 +45,58 @@ from scripts.zns import Zone
 # LBA Format Extension Data Structure
 # Zone Descriptor Extension Size bit 71:64 (ZDES)
 # Zone Size 63:0 (ZSZE)
-def get_zone_desctr_size(nvme0,buf):
+def get_zone_desctr_size(nvme0, buf):
     nvme0.identify(buf, nsid=0, cns=5, csi=2).waitdone()
-    zone_desctr_size = buf.data(3833,3832)
+    zone_desctr_size = buf.data(3833, 3832)
     return zone_desctr_size
 
-def get_zone_size(nvme0,buf):
+
+def get_zone_size(nvme0, buf):
     nvme0.identify(buf, nsid=0, cns=5, csi=2).waitdone()
     zone_size = buf.data(3831, 3824)
-    #return 0x8000
+    if zone_size == 0:
+        zone_size = 0x8000
     return zone_size
+
+
+def get_num_of_zones(nvme0n1, qpair, buf):
+    nvme0n1.zns_mgmt_receive(qpair, buf).waitdone()
+    nzones = buf.data(7, 0)
+    return nzones
+
+
+def get_zns_size(nvme0, nvme0n1, qpair, buf):
+    nzones = get_num_of_zones(nvme0n1, qpair, buf)
+    zone_size = get_zone_size(nvme0, buf)
+    return (nzones * zone_size)
+
 
 def get_cap_css(nvme0):
     css = ((nvme0.cap >> 32) & 0x1FE0) >> 5
     logging.debug("CAP.CSS= 0x%x" % css)
-    #return 0x40
     return css
+
+
+def get_zslba_list(nvme0, nvme0n1, qpair, buf):
+    zone_size = get_zone_size(nvme0, buf)
+    zns_size = get_zns_size(nvme0, nvme0n1, qpair, buf)
+    logging.info("zone size:0x%x, Total:0x%x" %(zone_size, zns_size))
+    return list(range(0, zns_size, zone_size))
+
+
+def test_reset_all_zones(nvme0, nvme0n1, qpair, buf):
+    css = get_cap_css(nvme0)
+    if not (css & 0x40):
+        pytest.skip("zns is not supported")
+
+    zone_size = get_zone_size(nvme0, buf)
+    zns_size = get_zns_size(nvme0, nvme0n1, qpair, buf)
+    for slba in range(0, zns_size, zone_size):
+        logging.info("Reset zone @zslba: 0x%x" % slba)
+        zone = Zone(qpair, nvme0n1, slba)
+        zone.reset()
+
+    test_zns_management_receive(nvme0, nvme0n1, qpair, buf)
 
 
 @pytest.fixture(scope="session")
@@ -70,21 +106,23 @@ def buf():
     del ret
 
 
-@pytest.fixture()
-def nvme0n1(nvme0):
+#@pytest.fixture()
+#def nvme0n1(nvme0):
     # only verify data in zone 0
-    ret = Namespace(nvme0, 1, 0x8000)
-    yield ret
-    ret.close()
+    # ret = Namespace(nvme0, 1, 0x8000)
+#    ret = Namespace(nvme0)
+#    yield ret
+#    ret.close()
 
 
 @pytest.fixture()
-def zone(nvme0, nvme0n1, qpair):
+def zone(nvme0, nvme0n1, qpair, buf):
     css = get_cap_css(nvme0)
     if not (css & 0x40):
         pytest.skip("zns is not supported")
-    
-    slba = 0x8000*int(random.random()*100)
+
+    zone_size = get_zone_size(nvme0, buf)
+    slba = zone_size*int(random.random()*100)
     ret = Zone(qpair, nvme0n1, slba)
     if ret.state == 'Full':
         ret.reset()
@@ -117,21 +155,21 @@ def test_zns_management_receive(nvme0, nvme0n1, qpair, buf):
     if not (css & 0x40):
         pytest.skip("zns is not supported")
     
-    zone_size = get_zone_size(nvme0,buf)
-    if zone_size == 0:
-        zone_size = 0x1000
+    zone_size = get_zone_size(nvme0, buf)
     nvme0n1.zns_mgmt_receive(qpair, buf).waitdone()
     nzones = buf.data(7, 0)
     logging.info("number of zones: %d" % nzones)
+    logging.info("zone size: 0x%x" % zone_size)
 
-    for i in range(10):
+    for i in range(nzones):
         base = 64
         nvme0n1.zns_mgmt_receive(qpair, buf, slba=i*zone_size).waitdone()
         zone_type = buf.data(base)
         assert zone_type == 2
 
         zone = Zone(qpair, nvme0n1, i*zone_size)
-        assert buf.data(base+1)>>4 == 14
+        assert zone.capacity <= zone_size
+        #assert buf.data(base+1)>>4 == 14
         assert buf.data(base+15, base+8) == zone.capacity
         logging.info(zone)
     
@@ -146,15 +184,15 @@ def test_zns_management_send(nvme0, nvme0n1, qpair):
     assert z0.state == 'Full'
 
 
-@pytest.mark.parametrize("slba", [0, 0x8000, 0x10000, 0x80000, 0x100000])
-def test_zns_state_machine(nvme0, nvme0n1, qpair, slba):
+@pytest.mark.parametrize("slba", [0, 0x8000, 0x10000, 0x18000, 0x38000])
+#@pytest.mark.parametrize("slba", zslba_list)
+def test_zns_state_machine(nvme0, nvme0n1, qpair, buf, slba):
     css = get_cap_css(nvme0)
     if not (css & 0x40):
         pytest.skip("zns is not supported")
 
     z0 = Zone(qpair, nvme0n1, slba)
-    assert z0.state == 'Full'
-    
+
     z0.reset()
     assert z0.state == 'Empty'
     
@@ -187,13 +225,65 @@ def test_zns_state_machine(nvme0, nvme0n1, qpair, slba):
     
     z0.close()
     assert z0.state == 'Closed'
+    
+    z0.finish()
+    assert z0.state == 'Full'
 
     z0.reset()
     assert z0.state == 'Empty'
     
-    z0.finish()
-    assert z0.state == 'Full'
-    
+
+def test_zns_state_machine1(nvme0, nvme0n1, qpair, buf):
+    css = get_cap_css(nvme0)
+    if not (css & 0x40):
+        pytest.skip("zns is not supported")
+
+    zslba = get_zslba_list(nvme0, nvme0n1, qpair, buf)    
+    for slba in zslba:
+        z0 = Zone(qpair, nvme0n1, slba)
+        logging.info("zslba:0x%x" % slba)
+
+        z0.reset()
+        assert z0.state == 'Empty'
+        
+        z0.open()
+        assert z0.state == 'Explicitly Opened'
+        
+        z0.close()
+        assert z0.state == 'Closed'
+
+        z0.open()
+        assert z0.state == 'Explicitly Opened'
+        
+        z0.close()
+        assert z0.state == 'Closed'
+
+        z0.finish()
+        assert z0.state == 'Full'
+        
+        z0.reset()
+        assert z0.state == 'Empty'
+
+        z0.open()
+        assert z0.state == 'Explicitly Opened'
+        
+        z0.reset()
+        assert z0.state == 'Empty'
+
+        z0.open()
+        assert z0.state == 'Explicitly Opened'
+        
+        z0.close()
+        assert z0.state == 'Closed'
+
+        z0.reset()
+        assert z0.state == 'Empty'
+        
+        z0.finish()
+        assert z0.state == 'Full'
+
+        z0.reset()
+
 
 def test_zns_show_zone(nvme0, nvme0n1, qpair, slba=0):
     css = get_cap_css(nvme0)
@@ -211,14 +301,32 @@ def test_zns_write_full_zone(nvme0, nvme0n1, qpair, slba=0):
 
     buf = Buffer(96*1024)
     z0 = Zone(qpair, nvme0n1, slba)
-    assert z0.state == 'Full'
-
     with pytest.warns(UserWarning, match="ERROR status: 01/"):
-        z0.write(qpair, buf, 0, 96//4).waitdone()
+        z0.write(qpair, buf, 0, 24).waitdone()
 
     z0.reset()
     z0.finish()
     assert z0.state == 'Full'
+
+
+def test_zns_fill_a_zone(nvme0, nvme0n1, qpair, buf):
+    css = get_cap_css(nvme0)
+    if not (css & 0x40):
+        pytest.skip("zns is not supported")
+
+    nzones = get_num_of_zones(nvme0n1, qpair, buf)
+    zone_size = get_zone_size(nvme0, buf)
+    slba = zone_size*int(random.randrange(nzones))
+    logging.info("Test zslba: 0x%x" % slba)
+    zone = Zone(qpair, nvme0n1, slba)
+    zone.reset()
+
+    for lba in range(slba, slba+zone_size, 8):
+        nvme0n1.write(qpair, buf, lba, 8).waitdone()
+
+    assert zone.state == 'Full'
+    # reset_all_zones(nvme0, nvme0n1, qpair, buf)
+    test_zns_management_receive(nvme0, nvme0n1, qpair, buf)
 
 
 def test_zns_write_1(nvme0, nvme0n1, qpair, zone):
@@ -227,7 +335,8 @@ def test_zns_write_1(nvme0, nvme0n1, qpair, zone):
         pytest.skip("zns is not supported")
 
     buf = Buffer(96*1024)
-    zone.write(qpair, buf, 0, 24)
+    zone.reset()
+    zone.write(qpair, buf, 0x0, 24).waitdone()
     zone.close()
     zone.finish()
     qpair.waitdone(1)
@@ -247,7 +356,7 @@ def test_zns_write_2(nvme0, nvme0n1, qpair, zone):
     qpair.waitdone(2)
     assert zone.state == 'Full'
 
-    
+
 def test_zns_write_192k(nvme0, nvme0n1, qpair, zone):
     css = get_cap_css(nvme0)
     if not (css & 0x40):
@@ -302,11 +411,12 @@ def test_zns_write_to_full(nvme0, nvme0n1, qpair, zone, io_counter=768):
         buf[i][8] = i%256
         zone.write(qpair, buf[i], i*24, 24)
     qpair.waitdone(io_counter)
-    assert zone.state == 'Full'
+    #assert zone.state == 'Full'
+    test_zns_management_receive(nvme0, nvme0n1, qpair, buf)
     
         
 @pytest.mark.parametrize("io_counter", [1, 2, 10, 39, 100, 255])
-def test_zns_write_and_read_multiple(nvme0, nvme0n1, qpair, zone, io_counter):
+def test_zns_write_and_read_multiple(nvme0, nvme0n1, qpair, zone, io_counter,buf):
     css = get_cap_css(nvme0)
     if not (css & 0x40):
         pytest.skip("zns is not supported")
@@ -318,7 +428,8 @@ def test_zns_write_and_read_multiple(nvme0, nvme0n1, qpair, zone, io_counter):
     zone.close()
     zone.finish()
     qpair.waitdone(io_counter)
-    assert zone.state == 'Full'
+    #assert zone.state == 'Full'
+    test_zns_management_receive(nvme0, nvme0n1, qpair, buf)
     
     for i in range(io_counter):
         buf = Buffer(96*1024)
@@ -381,7 +492,7 @@ def test_zns_write_explicitly_open(nvme0, nvme0n1, qpair, buf, zone, repeat):
 
 
 @pytest.mark.parametrize("repeat", range(10)) #100
-@pytest.mark.parametrize("slba", [0, 0x8000, 0x100000])
+@pytest.mark.parametrize("slba", [0, 0x8000, 0x38000])
 def test_zns_write_implicitly_open(nvme0, nvme0n1, qpair, slba, repeat):
     css = get_cap_css(nvme0)
     if not (css & 0x40):
@@ -389,7 +500,7 @@ def test_zns_write_implicitly_open(nvme0, nvme0n1, qpair, slba, repeat):
 
     buf = Buffer(96*1024)
     z0 = Zone(qpair, nvme0n1, slba)
-    assert z0.state == 'Full'
+    #assert z0.state == 'Full'
     
     z0.reset()
     assert z0.state == 'Empty'

--- a/07_zns/test_zns.py
+++ b/07_zns/test_zns.py
@@ -339,7 +339,7 @@ def test_zns_ioworker(nvme0, nvme0n1, qpair, buf):
     slba = zone_size*int(random.randrange(nzones))
     logging.info("Test zslba: 0x%x" % slba)
     zone = Zone(qpair, nvme0n1, slba)
-    zone.reset()
+    zone.reset()    
 
     nvme0n1.ioworker(io_size=8, lba_random=False, read_percentage=0, \
             region_start=slba, region_end=slba+zone_size).start().close()
@@ -347,6 +347,31 @@ def test_zns_ioworker(nvme0, nvme0n1, qpair, buf):
     assert zone.state == 'Full'
     # reset_all_zones(nvme0, nvme0n1, qpair, buf)
     test_zns_management_receive(nvme0, nvme0n1, qpair, buf)
+
+
+def test_zns_transition_next_zone(nvme0, nvme0n1, qpair, buf):
+    css = get_cap_css(nvme0)
+    if not (css & 0x40):
+        pytest.skip("zns is not supported")
+
+    nzones = get_num_of_zones(nvme0n1, qpair, buf)
+    zone_size = get_zone_size(nvme0, buf)
+    zone_index = int(random.randrange(nzones))
+    next_index = (zone_index + 1) % nzones
+    slba = zone_size * zone_index
+    logging.info("Test zslba: 0x%x" % slba)
+    zone = Zone(qpair, nvme0n1, slba)
+    zone.reset()
+    next_zone = Zone(qpair, nvme0n1, next_index*zone_size)
+    next_zone.reset()
+
+    nvme0n1.ioworker(io_size=8, lba_random=False, read_percentage=0, \
+            region_start=slba, region_end=slba+zone_size+128).start().close()
+
+    assert zone.state == 'Full'
+    assert next_zone.state == 'Implicitly Opened'
+    # reset_all_zones(nvme0, nvme0n1, qpair, buf)
+    test_zns_management_receive(nvme0, nvme0n1, qpair, buf)    
     
 
 def test_zns_write_1(nvme0, nvme0n1, qpair, zone):


### PR DESCRIPTION
Used zone size, number of zones and namespace size to construct tests.

Zone state machine to use loop through all zones, failed to use parameterize all zones?

Added to fill up a random zone using nvme0n1.write, but still have trouble to use zone.write.

scripts/conformance/07_zns/test_zns.py::test_zns_management_receive 
-------------------------------- live log setup --------------------------------
[2020-10-09 00:01:21.486] INFO script(60): setup random seed: 0xad8b39b8
-------------------------------- live log call ---------------------------------
[2020-10-09 00:01:21.550] INFO test_zns_management_receive(144): number of zones: 8
[2020-10-09 00:01:21.551] INFO test_zns_management_receive(145): zone size: 0x8000
[2020-10-09 00:01:21.552] INFO test_zns_management_receive(157): zone slba 0x0, state Empty, capacity 0x8000, write pointer 0x0
[2020-10-09 00:01:21.553] INFO test_zns_management_receive(157): zone slba 0x8000, state Empty, capacity 0x8000, write pointer 0x8000
[2020-10-09 00:01:21.567] INFO test_zns_management_receive(157): zone slba 0x10000, state Empty, capacity 0x8000, write pointer 0x10000
[2020-10-09 00:01:21.568] INFO test_zns_management_receive(157): zone slba 0x18000, state Empty, capacity 0x8000, write pointer 0x18000
[2020-10-09 00:01:21.569] INFO test_zns_management_receive(157): zone slba 0x20000, state Empty, capacity 0x8000, write pointer 0x20000
[2020-10-09 00:01:21.571] INFO test_zns_management_receive(157): zone slba 0x28000, state Empty, capacity 0x8000, write pointer 0x28000
[2020-10-09 00:01:21.572] INFO test_zns_management_receive(157): zone slba 0x30000, state Empty, capacity 0x8000, write pointer 0x30000
[2020-10-09 00:01:21.573] INFO test_zns_management_receive(157): zone slba 0x38000, state Empty, capacity 0x8000, write pointer 0x38000
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-09 00:01:21.583] INFO script(62): test duration: 0.098 sec









scripts/conformance/07_zns/test_zns.py::test_zns_state_machine[0] 
-------------------------------- live log setup --------------------------------
[2020-10-09 09:03:13.734] INFO script(60): setup random seed: 0x3f6cc21b
PASSED                                                                   [ 20%]
------------------------------ live log teardown -------------------------------
[2020-10-09 09:03:14.976] INFO script(62): test duration: 1.242 sec

scripts/conformance/07_zns/test_zns.py::test_zns_state_machine[32768] 
-------------------------------- live log setup --------------------------------
[2020-10-09 09:03:14.981] INFO script(60): setup random seed: 0x3f7fc947
PASSED                                                                   [ 40%]
------------------------------ live log teardown -------------------------------
[2020-10-09 09:03:15.101] INFO script(62): test duration: 0.120 sec

scripts/conformance/07_zns/test_zns.py::test_zns_state_machine[65536] 
-------------------------------- live log setup --------------------------------
[2020-10-09 09:03:15.105] INFO script(60): setup random seed: 0x3f81ae95
PASSED                                                                   [ 60%]
------------------------------ live log teardown -------------------------------
[2020-10-09 09:03:15.301] INFO script(62): test duration: 0.196 sec

scripts/conformance/07_zns/test_zns.py::test_zns_state_machine[98304] 
-------------------------------- live log setup --------------------------------
[2020-10-09 09:03:15.306] INFO script(60): setup random seed: 0x3f84bf61
PASSED                                                                   [ 80%]
------------------------------ live log teardown -------------------------------
[2020-10-09 09:03:15.602] INFO script(62): test duration: 0.296 sec

scripts/conformance/07_zns/test_zns.py::test_zns_state_machine[229376] 
-------------------------------- live log setup --------------------------------
[2020-10-09 09:03:15.605] INFO script(60): setup random seed: 0x3f8950d8
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-09 09:03:15.751] INFO script(62): test duration: 0.146 sec

scripts/conformance/07_zns/test_zns.py::test_zns_state_machine1 
-------------------------------- live log setup --------------------------------
[2020-10-09 09:06:18.791] INFO script(60): setup random seed: 0x4a74817f
-------------------------------- live log call ---------------------------------
[2020-10-09 09:06:18.862] INFO get_zslba_list(82): zone size:0x8000, Total:0x40000
[2020-10-09 09:06:18.863] INFO test_zns_state_machine1(230): zslba:0x0
[2020-10-09 09:06:18.868] INFO test_zns_state_machine1(230): zslba:0x8000
[2020-10-09 09:06:18.884] INFO test_zns_state_machine1(230): zslba:0x10000
[2020-10-09 09:06:18.888] INFO test_zns_state_machine1(230): zslba:0x18000
[2020-10-09 09:06:18.891] INFO test_zns_state_machine1(230): zslba:0x20000
[2020-10-09 09:06:18.909] INFO test_zns_state_machine1(230): zslba:0x28000
[2020-10-09 09:06:18.914] INFO test_zns_state_machine1(230): zslba:0x30000
[2020-10-09 09:06:18.922] INFO test_zns_state_machine1(230): zslba:0x38000
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-09 09:06:19.040] INFO script(62): test duration: 0.249 sec

scripts/conformance/07_zns/test_zns.py::test_zns_fill_a_zone 
-------------------------------- live log setup --------------------------------
[2020-10-09 10:42:17.846] INFO script(60): setup random seed: 0xa1b8b526
-------------------------------- live log call ---------------------------------
[2020-10-09 10:42:17.916] INFO test_zns_fill_a_zone(332): Test zslba: 0x10000
[2020-10-09 10:42:19.133] INFO test_zns_management_receive(145): number of zones: 8
[2020-10-09 10:42:19.134] INFO test_zns_management_receive(146): zone size: 0x8000
[2020-10-09 10:42:19.134] INFO test_zns_management_receive(158): zone slba 0x0, state Closed, capacity 0x8000, write pointer 0x1ff8
[2020-10-09 10:42:19.136] INFO test_zns_management_receive(158): zone slba 0x8000, state Closed, capacity 0x8000, write pointer 0x9ff8
[2020-10-09 10:42:19.138] INFO test_zns_management_receive(158): zone slba 0x10000, state Full, capacity 0x8000, write pointer 0x18000
[2020-10-09 10:42:19.144] INFO test_zns_management_receive(158): zone slba 0x18000, state Empty, capacity 0x8000, write pointer 0x18000
[2020-10-09 10:42:19.146] INFO test_zns_management_receive(158): zone slba 0x20000, state Empty, capacity 0x8000, write pointer 0x20000
[2020-10-09 10:42:19.147] INFO test_zns_management_receive(158): zone slba 0x28000, state Empty, capacity 0x8000, write pointer 0x28000
[2020-10-09 10:42:19.149] INFO test_zns_management_receive(158): zone slba 0x30000, state Empty, capacity 0x8000, write pointer 0x30000
[2020-10-09 10:42:19.150] INFO test_zns_management_receive(158): zone slba 0x38000, state Empty, capacity 0x8000, write pointer 0x38000
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-09 10:42:19.974] INFO script(62): test duration: 2.128 sec


=============================== warnings summary ===============================
scripts/conformance/07_zns/test_zns.py::test_zns_fill_a_zone
  /home/ygao/pynvme/scripts/conformance/07_zns/test_zns.py:55: UserWarning: ERROR status: 00/0b
    nvme0.identify(buf, nsid=0, cns=5, csi=2).waitdone()

-- Docs: https://docs.pytest.org/en/stable/warnings.html
-------------- generated xml file: /tmp/tmp-1755jcvotA20Zg56.xml ---------------
========================= 1 passed, 1 warning in 2.17s =========================
python /home/ygao/.vscode-server/extensions/ms-python.python-2020.6.91350/pythonFiles/testing_tools/run_adapter.py discover pytest -- --rootdir /home/ygao/pynvme -s --cache-clear --pciaddr=0000:00:03.0
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.1.0, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: excel-1.4.1, cov-2.10.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_zns_fill_a_zone 
-------------------------------- live log setup --------------------------------
[2020-10-09 10:43:13.755] INFO script(60): setup random seed: 0xa50dd0bb
-------------------------------- live log call ---------------------------------
[2020-10-09 10:43:13.824] INFO test_zns_fill_a_zone(332): Test zslba: 0x38000
[2020-10-09 10:43:14.904] INFO test_zns_management_receive(145): number of zones: 8
[2020-10-09 10:43:14.905] INFO test_zns_management_receive(146): zone size: 0x8000
[2020-10-09 10:43:14.905] INFO test_zns_management_receive(158): zone slba 0x0, state Closed, capacity 0x8000, write pointer 0x1ff8
[2020-10-09 10:43:14.907] INFO test_zns_management_receive(158): zone slba 0x8000, state Closed, capacity 0x8000, write pointer 0x9ff8
[2020-10-09 10:43:14.908] INFO test_zns_management_receive(158): zone slba 0x10000, state Full, capacity 0x8000, write pointer 0x18000
[2020-10-09 10:43:14.909] INFO test_zns_management_receive(158): zone slba 0x18000, state Empty, capacity 0x8000, write pointer 0x18000
[2020-10-09 10:43:14.911] INFO test_zns_management_receive(158): zone slba 0x20000, state Empty, capacity 0x8000, write pointer 0x20000
[2020-10-09 10:43:14.912] INFO test_zns_management_receive(158): zone slba 0x28000, state Empty, capacity 0x8000, write pointer 0x28000
[2020-10-09 10:43:14.914] INFO test_zns_management_receive(158): zone slba 0x30000, state Empty, capacity 0x8000, write pointer 0x30000
[2020-10-09 10:43:14.915] INFO test_zns_management_receive(158): zone slba 0x38000, state Full, capacity 0x8000, write pointer 0x40000
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-09 10:43:15.911] INFO script(62): test duration: 2.156 sec



why the following paramter from a zone slba list did not work?
@pytest.mark.parametrize("slba", zslba_list)

Add test of transition to the next zone, the first zone should be full and next zone should be implicitly open:

scripts/conformance/07_zns/test_zns.py::test_zns_transition_next_zone 
-------------------------------- live log setup --------------------------------
[2020-10-09 19:53:29.365] INFO script(60): setup random seed: 0x54f00d02
-------------------------------- live log call ---------------------------------
[2020-10-09 19:53:29.454] INFO test_zns_transition_next_zone(362): Test zslba: 0x20000
[2020-10-09 19:53:29.501] INFO test_zns_transition_next_zone(368): fill region with io count: 4112
[2020-10-09 19:53:30.353] INFO test_zns_management_receive(161): number of zones: 8
[2020-10-09 19:53:30.354] INFO test_zns_management_receive(162): zone size: 0x8000
[2020-10-09 19:53:30.354] INFO test_zns_management_receive(174): zone slba 0x0, state Full, capacity 0x8000, write pointer 0x8000
[2020-10-09 19:53:30.356] INFO test_zns_management_receive(174): zone slba 0x8000, state Full, capacity 0x8000, write pointer 0x10000
[2020-10-09 19:53:30.357] INFO test_zns_management_receive(174): zone slba 0x10000, state Empty, capacity 0x8000, write pointer 0x10000
[2020-10-09 19:53:30.359] INFO test_zns_management_receive(174): zone slba 0x18000, state Full, capacity 0x8000, write pointer 0x20000
[2020-10-09 19:53:30.360] INFO test_zns_management_receive(174): zone slba 0x20000, state Full, capacity 0x8000, write pointer 0x28000
[2020-10-09 19:53:30.362] INFO test_zns_management_receive(174): zone slba 0x28000, state Implicitly Opened, capacity 0x8000, write pointer 0x28080
[2020-10-09 19:53:30.363] INFO test_zns_management_receive(174): zone slba 0x30000, state Full, capacity 0x8000, write pointer 0x38000
[2020-10-09 19:53:30.365] INFO test_zns_management_receive(174): zone slba 0x38000, state Full, capacity 0x8000, write pointer 0x40000
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-09 19:53:31.578] INFO script(62): test duration: 2.213 sec

