### PR TITLE
Use fixtures for zone parameters

### DIFF
--- a/07_zns/test_zns.py
+++ b/07_zns/test_zns.py
@@ -45,22 +45,58 @@ from scripts.zns import Zone
 # LBA Format Extension Data Structure
 # Zone Descriptor Extension Size bit 71:64 (ZDES)
 # Zone Size 63:0 (ZSZE)
-def get_zone_desctr_size(nvme0,buf):
+def get_zone_desctr_size(nvme0, buf):
     nvme0.identify(buf, nsid=0, cns=5, csi=2).waitdone()
-    zone_desctr_size = buf.data(3833,3832)
+    zone_desctr_size = buf.data(3833, 3832)
     return zone_desctr_size
 
-def get_zone_size(nvme0,buf):
+
+def get_zone_size(nvme0, buf):
     nvme0.identify(buf, nsid=0, cns=5, csi=2).waitdone()
     zone_size = buf.data(3831, 3824)
-    #return 0x8000
+    if zone_size == 0:
+        zone_size = 0x8000
     return zone_size
+
+
+def get_num_of_zones(nvme0n1, qpair, buf):
+    nvme0n1.zns_mgmt_receive(qpair, buf).waitdone()
+    nzones = buf.data(7, 0)
+    return nzones
+
+
+def get_zns_size(nvme0, nvme0n1, qpair, buf):
+    nzones = get_num_of_zones(nvme0n1, qpair, buf)
+    zone_size = get_zone_size(nvme0, buf)
+    return (nzones * zone_size)
+
 
 def get_cap_css(nvme0):
     css = ((nvme0.cap >> 32) & 0x1FE0) >> 5
     logging.debug("CAP.CSS= 0x%x" % css)
-    #return 0x40
     return css
+
+
+def get_zslba_list(nvme0, nvme0n1, qpair, buf):
+    zone_size = get_zone_size(nvme0, buf)
+    zns_size = get_zns_size(nvme0, nvme0n1, qpair, buf)
+    logging.info("zone size:0x%x, Total:0x%x" %(zone_size, zns_size))
+    return list(range(0, zns_size, zone_size))
+
+
+def test_reset_all_zones(nvme0, nvme0n1, qpair, buf):
+    css = get_cap_css(nvme0)
+    if not (css & 0x40):
+        pytest.skip("zns is not supported")
+
+    zone_size = get_zone_size(nvme0, buf)
+    zns_size = get_zns_size(nvme0, nvme0n1, qpair, buf)
+    for slba in range(0, zns_size, zone_size):
+        logging.info("Reset zone @zslba: 0x%x" % slba)
+        zone = Zone(qpair, nvme0n1, slba)
+        zone.reset()
+
+    test_zns_management_receive(nvme0, nvme0n1, qpair, buf)
 
 
 @pytest.fixture(scope="session")
@@ -70,21 +106,23 @@ def buf():
     del ret
 
 
-@pytest.fixture()
-def nvme0n1(nvme0):
+#@pytest.fixture()
+#def nvme0n1(nvme0):
     # only verify data in zone 0
-    ret = Namespace(nvme0, 1, 0x8000)
-    yield ret
-    ret.close()
+    # ret = Namespace(nvme0, 1, 0x8000)
+#    ret = Namespace(nvme0)
+#    yield ret
+#    ret.close()
 
 
 @pytest.fixture()
-def zone(nvme0, nvme0n1, qpair):
+def zone(nvme0, nvme0n1, qpair, buf):
     css = get_cap_css(nvme0)
     if not (css & 0x40):
         pytest.skip("zns is not supported")
-    
-    slba = 0x8000*int(random.random()*100)
+
+    zone_size = get_zone_size(nvme0, buf)
+    slba = zone_size*int(random.random()*100)
     ret = Zone(qpair, nvme0n1, slba)
     if ret.state == 'Full':
         ret.reset()
@@ -117,21 +155,21 @@ def test_zns_management_receive(nvme0, nvme0n1, qpair, buf):
     if not (css & 0x40):
         pytest.skip("zns is not supported")
     
-    zone_size = get_zone_size(nvme0,buf)
-    if zone_size == 0:
-        zone_size = 0x1000
+    zone_size = get_zone_size(nvme0, buf)
     nvme0n1.zns_mgmt_receive(qpair, buf).waitdone()
     nzones = buf.data(7, 0)
     logging.info("number of zones: %d" % nzones)
+    logging.info("zone size: 0x%x" % zone_size)
 
-    for i in range(10):
+    for i in range(nzones):
         base = 64
         nvme0n1.zns_mgmt_receive(qpair, buf, slba=i*zone_size).waitdone()
         zone_type = buf.data(base)
         assert zone_type == 2
 
         zone = Zone(qpair, nvme0n1, i*zone_size)
-        assert buf.data(base+1)>>4 == 14
+        assert zone.capacity <= zone_size
+        #assert buf.data(base+1)>>4 == 14
         assert buf.data(base+15, base+8) == zone.capacity
         logging.info(zone)
     
@@ -146,15 +184,15 @@ def test_zns_management_send(nvme0, nvme0n1, qpair):
     assert z0.state == 'Full'
 
 
-@pytest.mark.parametrize("slba", [0, 0x8000, 0x10000, 0x80000, 0x100000])
-def test_zns_state_machine(nvme0, nvme0n1, qpair, slba):
+@pytest.mark.parametrize("slba", [0, 0x8000, 0x10000, 0x18000, 0x38000])
+#@pytest.mark.parametrize("slba", zslba_list)
+def test_zns_state_machine(nvme0, nvme0n1, qpair, buf, slba):
     css = get_cap_css(nvme0)
     if not (css & 0x40):
         pytest.skip("zns is not supported")
 
     z0 = Zone(qpair, nvme0n1, slba)
-    assert z0.state == 'Full'
-    
+
     z0.reset()
     assert z0.state == 'Empty'
     
@@ -187,13 +225,65 @@ def test_zns_state_machine(nvme0, nvme0n1, qpair, slba):
     
     z0.close()
     assert z0.state == 'Closed'
+    
+    z0.finish()
+    assert z0.state == 'Full'
 
     z0.reset()
     assert z0.state == 'Empty'
     
-    z0.finish()
-    assert z0.state == 'Full'
-    
+
+def test_zns_state_machine1(nvme0, nvme0n1, qpair, buf):
+    css = get_cap_css(nvme0)
+    if not (css & 0x40):
+        pytest.skip("zns is not supported")
+
+    zslba = get_zslba_list(nvme0, nvme0n1, qpair, buf)    
+    for slba in zslba:
+        z0 = Zone(qpair, nvme0n1, slba)
+        logging.info("zslba:0x%x" % slba)
+
+        z0.reset()
+        assert z0.state == 'Empty'
+        
+        z0.open()
+        assert z0.state == 'Explicitly Opened'
+        
+        z0.close()
+        assert z0.state == 'Closed'
+
+        z0.open()
+        assert z0.state == 'Explicitly Opened'
+        
+        z0.close()
+        assert z0.state == 'Closed'
+
+        z0.finish()
+        assert z0.state == 'Full'
+        
+        z0.reset()
+        assert z0.state == 'Empty'
+
+        z0.open()
+        assert z0.state == 'Explicitly Opened'
+        
+        z0.reset()
+        assert z0.state == 'Empty'
+
+        z0.open()
+        assert z0.state == 'Explicitly Opened'
+        
+        z0.close()
+        assert z0.state == 'Closed'
+
+        z0.reset()
+        assert z0.state == 'Empty'
+        
+        z0.finish()
+        assert z0.state == 'Full'
+
+        z0.reset()
+
 
 def test_zns_show_zone(nvme0, nvme0n1, qpair, slba=0):
     css = get_cap_css(nvme0)
@@ -211,14 +301,32 @@ def test_zns_write_full_zone(nvme0, nvme0n1, qpair, slba=0):
 
     buf = Buffer(96*1024)
     z0 = Zone(qpair, nvme0n1, slba)
-    assert z0.state == 'Full'
-
     with pytest.warns(UserWarning, match="ERROR status: 01/"):
-        z0.write(qpair, buf, 0, 96//4).waitdone()
+        z0.write(qpair, buf, 0, 24).waitdone()
 
     z0.reset()
     z0.finish()
     assert z0.state == 'Full'
+
+
+def test_zns_fill_a_zone(nvme0, nvme0n1, qpair, buf):
+    css = get_cap_css(nvme0)
+    if not (css & 0x40):
+        pytest.skip("zns is not supported")
+
+    nzones = get_num_of_zones(nvme0n1, qpair, buf)
+    zone_size = get_zone_size(nvme0, buf)
+    slba = zone_size*int(random.randrange(nzones))
+    logging.info("Test zslba: 0x%x" % slba)
+    zone = Zone(qpair, nvme0n1, slba)
+    zone.reset()
+
+    for lba in range(slba, slba+zone_size, 8):
+        nvme0n1.write(qpair, buf, lba, 8).waitdone()
+
+    assert zone.state == 'Full'
+    # reset_all_zones(nvme0, nvme0n1, qpair, buf)
+    test_zns_management_receive(nvme0, nvme0n1, qpair, buf)
 
 
 def test_zns_write_1(nvme0, nvme0n1, qpair, zone):
@@ -227,7 +335,8 @@ def test_zns_write_1(nvme0, nvme0n1, qpair, zone):
         pytest.skip("zns is not supported")
 
     buf = Buffer(96*1024)
-    zone.write(qpair, buf, 0, 24)
+    zone.reset()
+    zone.write(qpair, buf, 0x0, 24).waitdone()
     zone.close()
     zone.finish()
     qpair.waitdone(1)
@@ -247,7 +356,7 @@ def test_zns_write_2(nvme0, nvme0n1, qpair, zone):
     qpair.waitdone(2)
     assert zone.state == 'Full'
 
-    
+
 def test_zns_write_192k(nvme0, nvme0n1, qpair, zone):
     css = get_cap_css(nvme0)
     if not (css & 0x40):
@@ -302,11 +411,12 @@ def test_zns_write_to_full(nvme0, nvme0n1, qpair, zone, io_counter=768):
         buf[i][8] = i%256
         zone.write(qpair, buf[i], i*24, 24)
     qpair.waitdone(io_counter)
-    assert zone.state == 'Full'
+    #assert zone.state == 'Full'
+    test_zns_management_receive(nvme0, nvme0n1, qpair, buf)
     
         
 @pytest.mark.parametrize("io_counter", [1, 2, 10, 39, 100, 255])
-def test_zns_write_and_read_multiple(nvme0, nvme0n1, qpair, zone, io_counter):
+def test_zns_write_and_read_multiple(nvme0, nvme0n1, qpair, zone, io_counter,buf):
     css = get_cap_css(nvme0)
     if not (css & 0x40):
         pytest.skip("zns is not supported")
@@ -318,7 +428,8 @@ def test_zns_write_and_read_multiple(nvme0, nvme0n1, qpair, zone, io_counter):
     zone.close()
     zone.finish()
     qpair.waitdone(io_counter)
-    assert zone.state == 'Full'
+    #assert zone.state == 'Full'
+    test_zns_management_receive(nvme0, nvme0n1, qpair, buf)
     
     for i in range(io_counter):
         buf = Buffer(96*1024)
@@ -381,7 +492,7 @@ def test_zns_write_explicitly_open(nvme0, nvme0n1, qpair, buf, zone, repeat):
 
 
 @pytest.mark.parametrize("repeat", range(10)) #100
-@pytest.mark.parametrize("slba", [0, 0x8000, 0x100000])
+@pytest.mark.parametrize("slba", [0, 0x8000, 0x38000])
 def test_zns_write_implicitly_open(nvme0, nvme0n1, qpair, slba, repeat):
     css = get_cap_css(nvme0)
     if not (css & 0x40):
@@ -389,7 +500,7 @@ def test_zns_write_implicitly_open(nvme0, nvme0n1, qpair, slba, repeat):
 
     buf = Buffer(96*1024)
     z0 = Zone(qpair, nvme0n1, slba)
-    assert z0.state == 'Full'
+    #assert z0.state == 'Full'
     
     z0.reset()
     assert z0.state == 'Empty'

--- a/07_zns/test_zns.py
+++ b/07_zns/test_zns.py
@@ -447,6 +447,9 @@ def test_zns_write_and_read_multiple(nvme0, nvme0n1, qpair, zone, io_counter,buf
         
 
 def test_zns_ioworker_baisc(zone, zone_size):
+    if zns_not_supported(nvme0):
+        pytest.skip("zns is not supported")
+        
     assert zone.state == 'Explicitly Opened'
     r = zone.ioworker(io_size=16, io_count=zone_size/16, qdepth=16).start().close()
     logging.info(r)

--- a/07_zns/test_zns.py
+++ b/07_zns/test_zns.py
@@ -339,7 +339,7 @@ def test_zns_ioworker(nvme0, nvme0n1, qpair, buf):
     slba = zone_size*int(random.randrange(nzones))
     logging.info("Test zslba: 0x%x" % slba)
     zone = Zone(qpair, nvme0n1, slba)
-    zone.reset()
+    zone.reset()    
 
     nvme0n1.ioworker(io_size=8, lba_random=False, read_percentage=0, \
             region_start=slba, region_end=slba+zone_size).start().close()
@@ -347,6 +347,31 @@ def test_zns_ioworker(nvme0, nvme0n1, qpair, buf):
     assert zone.state == 'Full'
     # reset_all_zones(nvme0, nvme0n1, qpair, buf)
     test_zns_management_receive(nvme0, nvme0n1, qpair, buf)
+
+
+def test_zns_transition_next_zone(nvme0, nvme0n1, qpair, buf):
+    css = get_cap_css(nvme0)
+    if not (css & 0x40):
+        pytest.skip("zns is not supported")
+
+    nzones = get_num_of_zones(nvme0n1, qpair, buf)
+    zone_size = get_zone_size(nvme0, buf)
+    zone_index = int(random.randrange(nzones))
+    next_index = (zone_index + 1) % nzones
+    slba = zone_size * zone_index
+    logging.info("Test zslba: 0x%x" % slba)
+    zone = Zone(qpair, nvme0n1, slba)
+    zone.reset()
+    next_zone = Zone(qpair, nvme0n1, next_index*zone_size)
+    next_zone.reset()
+
+    nvme0n1.ioworker(io_size=8, lba_random=False, read_percentage=0, \
+            region_start=slba, region_end=slba+zone_size+128).start().close()
+
+    assert zone.state == 'Full'
+    assert next_zone.state == 'Implicitly Opened'
+    # reset_all_zones(nvme0, nvme0n1, qpair, buf)
+    test_zns_management_receive(nvme0, nvme0n1, qpair, buf)    
     
 
 def test_zns_write_1(nvme0, nvme0n1, qpair, zone):

--- a/07_zns/test_zns.py
+++ b/07_zns/test_zns.py
@@ -115,8 +115,6 @@ def test_reset_all_zones(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones, zn
     if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
 
-    #zone_size = get_zone_size(nvme0, buf)
-    #zns_size = get_zns_size(nvme0, nvme0n1, qpair, buf)
     for slba in range(0, zns_size, zone_size):
         logging.info("Reset zone @zslba: 0x%x" % slba)
         zone = Zone(qpair, nvme0n1, slba)
@@ -146,9 +144,6 @@ def test_zns_management_receive(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zo
     if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
     
-    #zone_size = get_zone_size(nvme0, buf)
-    #nvme0n1.zns_mgmt_receive(qpair, buf).waitdone()
-    #nzones = buf.data(7, 0)
     logging.info("number of zones: %d" % num_of_zones)
     logging.info("zone size: 0x%x" % zone_size)
 
@@ -225,8 +220,7 @@ def test_zns_state_machine(nvme0, nvme0n1, qpair, buf, slba):
 def test_zns_state_machine_all(nvme0, nvme0n1, qpair, buf, zslba_list):
     if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
-
-    #zslba = get_zslba_list(nvme0, nvme0n1, qpair, buf)    
+   
     for slba in zslba_list:
         z0 = Zone(qpair, nvme0n1, slba)
         logging.info("zslba:0x%x" % slba)
@@ -299,8 +293,6 @@ def test_zns_fill_a_zone(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones):
     if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
 
-    #nzones = get_num_of_zones(nvme0n1, qpair, buf)
-    #zone_size = get_zone_size(nvme0, buf)
     slba = zone_size*int(random.randrange(num_of_zones))
     logging.info("Test zslba: 0x%x" % slba)
     zone = Zone(qpair, nvme0n1, slba)
@@ -311,7 +303,7 @@ def test_zns_fill_a_zone(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones):
     for lba in range(0, zone_size+16, 16):
         zone.write(qpair, buf, lba, 16).waitdone()
 
-    #assert zone.state == 'Full'
+    assert zone.state == 'Full'
     test_zns_management_receive(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones)
 
 
@@ -319,8 +311,6 @@ def test_zns_ioworker(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones):
     if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
 
-    #nzones = get_num_of_zones(nvme0n1, qpair, buf)
-    #zone_size = get_zone_size(nvme0, buf)
     slba = zone_size*int(random.randrange(num_of_zones))
     logging.info("Test zslba: 0x%x" % slba)
     zone = Zone(qpair, nvme0n1, slba)
@@ -330,7 +320,6 @@ def test_zns_ioworker(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones):
             region_start=slba, region_end=slba+zone_size).start().close()
 
     assert zone.state == 'Full'
-    # reset_all_zones(nvme0, nvme0n1, qpair, buf)
     test_zns_management_receive(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones)
 
 
@@ -338,8 +327,6 @@ def test_zns_transition_next_zone(nvme0, nvme0n1, qpair, buf, zone_size, num_of_
     if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
 
-    #nzones = get_num_of_zones(nvme0n1, qpair, buf)
-    #zone_size = get_zone_size(nvme0, buf)
     zone_index = int(random.randrange(num_of_zones))
     if zone_index == num_of_zones:
         zone_index = num_of_zones - 1

--- a/07_zns/test_zns.py
+++ b/07_zns/test_zns.py
@@ -2,6 +2,7 @@
 #  BSD LICENSE
 #
 #  Copyright (c) Crane Chu <cranechu@gmail.com>
+#  Copyright (c) Wayne Gao <yfwayne@hotmail.com>
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -42,61 +43,53 @@ from nvme import Controller, Namespace, Buffer, Qpair, Pcie, Subsystem, __versio
 from scripts.zns import Zone
 
 
+
+#@pytest.fixture( )
+def zns_not_supported(nvme0):
+    cap_css = ((nvme0.cap >> 32) & 0x1FE0) >> 5
+    logging.debug("CAP.CSS= 0x%x" % cap_css)
+    return not (cap_css & 0x40)
+
+#pytestmark = pytest.mark.skipif(zns_not_supported(nvme0), reason="zns is not supported")  
+
+
 # LBA Format Extension Data Structure
 # Zone Descriptor Extension Size bit 71:64 (ZDES)
 # Zone Size 63:0 (ZSZE)
-def get_zone_desctr_size(nvme0, buf):
-    nvme0.identify(buf, nsid=0, cns=5, csi=2).waitdone()
-    zone_desctr_size = buf.data(3833, 3832)
-    return zone_desctr_size
+@pytest.fixture( )
+def zone_desctr_size(nvme0, buf):
+    nvme0.identify(buf, nsid=1, cns=5, csi=2).waitdone()
+    ret = buf.data(3833, 3832)
+    return ret
 
 
-def get_zone_size(nvme0, buf):
-    nvme0.identify(buf, nsid=0, cns=5, csi=2).waitdone()
-    zone_size = buf.data(3831, 3824)
-    if zone_size == 0:
-        zone_size = 0x8000
-    return zone_size
+@pytest.fixture( )
+def zone_size(nvme0, buf):
+    nvme0.identify(buf, nsid=1, cns=5, csi=2).waitdone()
+    ret = buf.data(3831, 3824)
+    logging.debug("zone size: 0x%x" % ret)
+    if ret == 0:
+        ret = 0x8000
+    return ret
 
 
-def get_num_of_zones(nvme0n1, qpair, buf):
+@pytest.fixture( )
+def num_of_zones(nvme0n1, qpair, buf):
     nvme0n1.zns_mgmt_receive(qpair, buf).waitdone()
-    nzones = buf.data(7, 0)
-    return nzones
+    ret = buf.data(7, 0)
+    return ret
 
 
-def get_zns_size(nvme0, nvme0n1, qpair, buf):
-    nzones = get_num_of_zones(nvme0n1, qpair, buf)
-    zone_size = get_zone_size(nvme0, buf)
-    return (nzones * zone_size)
+@pytest.fixture( )
+def zns_size(num_of_zones, zone_size):
+    ret = num_of_zones * zone_size
+    return ret
 
 
-def get_cap_css(nvme0):
-    css = ((nvme0.cap >> 32) & 0x1FE0) >> 5
-    logging.debug("CAP.CSS= 0x%x" % css)
-    return css
-
-
-def get_zslba_list(nvme0, nvme0n1, qpair, buf):
-    zone_size = get_zone_size(nvme0, buf)
-    zns_size = get_zns_size(nvme0, nvme0n1, qpair, buf)
-    logging.info("zone size:0x%x, Total:0x%x" %(zone_size, zns_size))
+@pytest.fixture( )
+def zslba_list(zone_size, zns_size):
+    logging.debug("zone size:0x%x, Total:0x%x" %(zone_size, zns_size))
     return list(range(0, zns_size, zone_size))
-
-
-def test_reset_all_zones(nvme0, nvme0n1, qpair, buf):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
-        pytest.skip("zns is not supported")
-
-    zone_size = get_zone_size(nvme0, buf)
-    zns_size = get_zns_size(nvme0, nvme0n1, qpair, buf)
-    for slba in range(0, zns_size, zone_size):
-        logging.info("Reset zone @zslba: 0x%x" % slba)
-        zone = Zone(qpair, nvme0n1, slba)
-        zone.reset()
-
-    test_zns_management_receive(nvme0, nvme0n1, qpair, buf)
 
 
 @pytest.fixture(scope="session")
@@ -106,31 +99,30 @@ def buf():
     del ret
 
 
-#@pytest.fixture()
-#def nvme0n1(nvme0):
-    # only verify data in zone 0
-    # ret = Namespace(nvme0, 1, 0x8000)
-#    ret = Namespace(nvme0)
-#    yield ret
-#    ret.close()
-
-
 @pytest.fixture()
-def zone(nvme0, nvme0n1, qpair, buf):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
-        pytest.skip("zns is not supported")
-
-    zone_size = get_zone_size(nvme0, buf)
-    slba = zone_size*int(random.random()*100)
+def zone(nvme0, nvme0n1, qpair, buf, num_of_zones, zone_size):
+    slba = zone_size*int(random.randrange(num_of_zones))
+    logging.debug("slba:0x%x" % slba )
     ret = Zone(qpair, nvme0n1, slba)
-    if ret.state == 'Full':
-        ret.reset()
-    if ret.state == 'Empty':
-        ret.open()
+    ret.reset()
+    ret.open()
     assert ret.state == 'Explicitly Opened'
     assert ret.wpointer == ret.slba
     return ret
+
+
+def test_reset_all_zones(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones, zns_size):
+    if zns_not_supported(nvme0):
+        pytest.skip("zns is not supported")
+
+    #zone_size = get_zone_size(nvme0, buf)
+    #zns_size = get_zns_size(nvme0, nvme0n1, qpair, buf)
+    for slba in range(0, zns_size, zone_size):
+        logging.info("Reset zone @zslba: 0x%x" % slba)
+        zone = Zone(qpair, nvme0n1, slba)
+        zone.reset()
+
+    test_zns_management_receive(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones)
 
 
 def test_dut_firmware_and_model_name(nvme0):
@@ -150,18 +142,17 @@ def test_zns_identify_namespace(nvme0, buf):
     logging.info(buf.dump(64))
     
 
-def test_zns_management_receive(nvme0, nvme0n1, qpair, buf):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
+def test_zns_management_receive(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones):
+    if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
     
-    zone_size = get_zone_size(nvme0, buf)
-    nvme0n1.zns_mgmt_receive(qpair, buf).waitdone()
-    nzones = buf.data(7, 0)
-    logging.info("number of zones: %d" % nzones)
+    #zone_size = get_zone_size(nvme0, buf)
+    #nvme0n1.zns_mgmt_receive(qpair, buf).waitdone()
+    #nzones = buf.data(7, 0)
+    logging.info("number of zones: %d" % num_of_zones)
     logging.info("zone size: 0x%x" % zone_size)
 
-    for i in range(nzones):
+    for i in range(num_of_zones):
         base = 64
         nvme0n1.zns_mgmt_receive(qpair, buf, slba=i*zone_size).waitdone()
         zone_type = buf.data(base)
@@ -175,8 +166,7 @@ def test_zns_management_receive(nvme0, nvme0n1, qpair, buf):
     
 
 def test_zns_management_send(nvme0, nvme0n1, qpair):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
+    if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
 
     z0 = Zone(qpair, nvme0n1, 0)
@@ -187,8 +177,7 @@ def test_zns_management_send(nvme0, nvme0n1, qpair):
 @pytest.mark.parametrize("slba", [0, 0x8000, 0x10000, 0x18000, 0x38000])
 #@pytest.mark.parametrize("slba", zslba_list)
 def test_zns_state_machine(nvme0, nvme0n1, qpair, buf, slba):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
+    if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
 
     z0 = Zone(qpair, nvme0n1, slba)
@@ -233,13 +222,12 @@ def test_zns_state_machine(nvme0, nvme0n1, qpair, buf, slba):
     assert z0.state == 'Empty'
     
 
-def test_zns_state_machine1(nvme0, nvme0n1, qpair, buf):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
+def test_zns_state_machine_all(nvme0, nvme0n1, qpair, buf, zslba_list):
+    if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
 
-    zslba = get_zslba_list(nvme0, nvme0n1, qpair, buf)    
-    for slba in zslba:
+    #zslba = get_zslba_list(nvme0, nvme0n1, qpair, buf)    
+    for slba in zslba_list:
         z0 = Zone(qpair, nvme0n1, slba)
         logging.info("zslba:0x%x" % slba)
 
@@ -286,8 +274,7 @@ def test_zns_state_machine1(nvme0, nvme0n1, qpair, buf):
 
 
 def test_zns_show_zone(nvme0, nvme0n1, qpair, slba=0):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
+    if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
 
     z0 = Zone(qpair, nvme0n1, slba)
@@ -295,48 +282,46 @@ def test_zns_show_zone(nvme0, nvme0n1, qpair, slba=0):
 
     
 def test_zns_write_full_zone(nvme0, nvme0n1, qpair, slba=0):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
+    if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
 
     buf = Buffer(96*1024)
     z0 = Zone(qpair, nvme0n1, slba)
-    with pytest.warns(UserWarning, match="ERROR status: 01/"):
-        z0.write(qpair, buf, 0, 24).waitdone()
+    #with pytest.warns(UserWarning, match="ERROR status: 01/"):
+    z0.write(qpair, buf, 0, 16).waitdone()
 
     z0.reset()
     z0.finish()
     assert z0.state == 'Full'
 
 
-def test_zns_fill_a_zone(nvme0, nvme0n1, qpair, buf):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
+def test_zns_fill_a_zone(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones):
+    if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
 
-    nzones = get_num_of_zones(nvme0n1, qpair, buf)
-    zone_size = get_zone_size(nvme0, buf)
-    slba = zone_size*int(random.randrange(nzones))
+    #nzones = get_num_of_zones(nvme0n1, qpair, buf)
+    #zone_size = get_zone_size(nvme0, buf)
+    slba = zone_size*int(random.randrange(num_of_zones))
     logging.info("Test zslba: 0x%x" % slba)
     zone = Zone(qpair, nvme0n1, slba)
     zone.reset()
 
-    for lba in range(slba, slba+zone_size, 8):
-        nvme0n1.write(qpair, buf, lba, 8).waitdone()
+    #for lba in range(slba, slba+zone_size, 8):
+    #    nvme0n1.write(qpair, buf, lba, 8).waitdone()
+    for lba in range(0, zone_size+16, 16):
+        zone.write(qpair, buf, lba, 16).waitdone()
 
-    assert zone.state == 'Full'
-    # reset_all_zones(nvme0, nvme0n1, qpair, buf)
-    test_zns_management_receive(nvme0, nvme0n1, qpair, buf)
+    #assert zone.state == 'Full'
+    test_zns_management_receive(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones)
 
 
-def test_zns_ioworker(nvme0, nvme0n1, qpair, buf):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
+def test_zns_ioworker(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones):
+    if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
 
-    nzones = get_num_of_zones(nvme0n1, qpair, buf)
-    zone_size = get_zone_size(nvme0, buf)
-    slba = zone_size*int(random.randrange(nzones))
+    #nzones = get_num_of_zones(nvme0n1, qpair, buf)
+    #zone_size = get_zone_size(nvme0, buf)
+    slba = zone_size*int(random.randrange(num_of_zones))
     logging.info("Test zslba: 0x%x" % slba)
     zone = Zone(qpair, nvme0n1, slba)
     zone.reset()    
@@ -346,23 +331,26 @@ def test_zns_ioworker(nvme0, nvme0n1, qpair, buf):
 
     assert zone.state == 'Full'
     # reset_all_zones(nvme0, nvme0n1, qpair, buf)
-    test_zns_management_receive(nvme0, nvme0n1, qpair, buf)
+    test_zns_management_receive(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones)
 
 
-def test_zns_transition_next_zone(nvme0, nvme0n1, qpair, buf):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
+def test_zns_transition_next_zone(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones):
+    if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
 
-    nzones = get_num_of_zones(nvme0n1, qpair, buf)
-    zone_size = get_zone_size(nvme0, buf)
-    zone_index = int(random.randrange(nzones))
-    next_index = (zone_index + 1) % nzones
+    #nzones = get_num_of_zones(nvme0n1, qpair, buf)
+    #zone_size = get_zone_size(nvme0, buf)
+    zone_index = int(random.randrange(num_of_zones))
+    if zone_index == num_of_zones:
+        zone_index = num_of_zones - 1
+    next_index = (zone_index + 1) % num_of_zones
     slba = zone_size * zone_index
+    next_slba = next_index*zone_size
     logging.info("Test zslba: 0x%x" % slba)
+    logging.info("Next zslba: 0x%x" % next_slba)
     zone = Zone(qpair, nvme0n1, slba)
     zone.reset()
-    next_zone = Zone(qpair, nvme0n1, next_index*zone_size)
+    next_zone = Zone(qpair, nvme0n1, next_slba)
     next_zone.reset()
 
     nvme0n1.ioworker(io_size=8, lba_random=False, read_percentage=0, \
@@ -370,27 +358,23 @@ def test_zns_transition_next_zone(nvme0, nvme0n1, qpair, buf):
 
     assert zone.state == 'Full'
     assert next_zone.state == 'Implicitly Opened'
-    # reset_all_zones(nvme0, nvme0n1, qpair, buf)
-    test_zns_management_receive(nvme0, nvme0n1, qpair, buf)    
+    test_zns_management_receive(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones)    
     
 
-def test_zns_write_1(nvme0, nvme0n1, qpair, zone):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
+def test_zns_write_1(nvme0, nvme0n1, qpair, zone, buf):
+    if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
 
-    buf = Buffer(96*1024)
+    #buf = Buffer(96*1024)
     zone.reset()
-    zone.write(qpair, buf, 0x0, 24).waitdone()
+    zone.write(qpair, buf, 0x0, 8).waitdone()
     zone.close()
     zone.finish()
-    qpair.waitdone(1)
     assert zone.state == 'Full'
 
     
 def test_zns_write_2(nvme0, nvme0n1, qpair, zone):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
+    if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
 
     buf = Buffer(96*1024)
@@ -403,8 +387,7 @@ def test_zns_write_2(nvme0, nvme0n1, qpair, zone):
 
 
 def test_zns_write_192k(nvme0, nvme0n1, qpair, zone):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
+    if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
 
     buf = Buffer(96*1024)
@@ -417,82 +400,74 @@ def test_zns_write_192k(nvme0, nvme0n1, qpair, zone):
 
     
 def test_zns_write_invalid_lba(nvme0, nvme0n1, qpair, zone):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
+    if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
         
     buf = Buffer(96*1024)
-    zone.write(qpair, buf, 0, 24)
+    zone.write(qpair, buf, 0, 24).waitdone()
     zone.write(qpair, buf, 24, 24).waitdone()
     with pytest.warns(UserWarning, match="ERROR status: 01/bc"):
         zone.write(qpair, buf, 24, 24).waitdone()
     zone.close()
     zone.finish()
-    qpair.waitdone(1)
     assert zone.state == 'Full'
 
 
 def test_zns_write_twice(nvme0, nvme0n1, qpair, zone):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
+    if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
     
     buf = Buffer(96*1024)
-    zone.write(qpair, buf, 0, 24)
     zone.write(qpair, buf, 0, 24).waitdone()
+    with pytest.warns(UserWarning, match="ERROR status: 01/bc"):
+        zone.write(qpair, buf, 0, 24).waitdone()
     zone.close()
     zone.finish()
-    qpair.waitdone(1)
     assert zone.state == 'Full'    
 
 
 def test_zns_write_to_full(nvme0, nvme0n1, qpair, zone, io_counter=768):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
+    if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
 
     buf = [Buffer(96*1024)]*768
     for i in range(io_counter):
         buf[i][8] = i%256
-        zone.write(qpair, buf[i], i*24, 24)
+        zone.write(qpair, buf[i], i*16, 16)
     qpair.waitdone(io_counter)
     #assert zone.state == 'Full'
-    test_zns_management_receive(nvme0, nvme0n1, qpair, buf)
+    #test_zns_management_receive(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones)
     
         
 @pytest.mark.parametrize("io_counter", [1, 2, 10, 39, 100, 255])
 def test_zns_write_and_read_multiple(nvme0, nvme0n1, qpair, zone, io_counter,buf):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
+    if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
 
     buf_list = [Buffer(96*1024) for i in range(io_counter)]
     for i in range(io_counter):
         buf_list[i][8] = i
-        zone.write(qpair, buf_list[i], i*24, 24)
+        zone.write(qpair, buf_list[i], i*16, 16).waitdone()
     zone.close()
     zone.finish()
-    qpair.waitdone(io_counter)
-    #assert zone.state == 'Full'
-    test_zns_management_receive(nvme0, nvme0n1, qpair, buf)
+    assert zone.state == 'Full'
     
     for i in range(io_counter):
         buf = Buffer(96*1024)
-        zone.read(qpair, buf, i*24, 24).waitdone()
+        zone.read(qpair, buf, i*16, 16).waitdone()
         logging.debug(buf.dump(16))
         assert buf[8] == i
         
 
-def _test_zns_ioworker_baisc(zone):
+def test_zns_ioworker_baisc(zone, zone_size):
     assert zone.state == 'Explicitly Opened'
-    r = zone.ioworker(io_size=24, io_count=768, qdepth=16).close()
+    r = zone.ioworker(io_size=16, io_count=zone_size/16, qdepth=16).start().close()
     logging.info(r)
     assert zone.state == 'Full'
     
     
 def test_zns_hello_world_2(nvme0, nvme0n1, qpair, zone, buf):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
+    if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
         
     buf[10:21] = b'hello world'
@@ -508,10 +483,9 @@ def test_zns_hello_world_2(nvme0, nvme0n1, qpair, zone, buf):
     assert read_buf[10:21] == b'hello world'
         
     
-@pytest.mark.parametrize("repeat", range(30)) #100
+@pytest.mark.parametrize("repeat", range(3)) #100
 def test_zns_write_explicitly_open(nvme0, nvme0n1, qpair, buf, zone, repeat):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
+    if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
         
     z0 = zone
@@ -519,28 +493,26 @@ def test_zns_write_explicitly_open(nvme0, nvme0n1, qpair, buf, zone, repeat):
     assert z0.state == 'Explicitly Opened'
     assert z0.wpointer == slba
 
-    z0.write(qpair, buf, 0, 96//4)
+    z0.write(qpair, buf, 0, 16).waitdone()
     time.sleep(1)
     assert z0.state == 'Explicitly Opened'
-    assert z0.wpointer == slba+0x18
+    assert z0.wpointer == slba+0x10
 
     z0.close()
     #logging.info(z0)
     assert z0.state == 'Closed'
-    assert z0.wpointer == slba+0x18
+    assert z0.wpointer == slba+0x10
     
     z0.finish()
-    qpair.waitdone()
     logging.info(z0)
     assert z0.state == 'Full'
-    assert z0.wpointer == slba+0x4800
+    assert z0.wpointer == slba+0x10
 
 
 @pytest.mark.parametrize("repeat", range(10)) #100
 @pytest.mark.parametrize("slba", [0, 0x8000, 0x38000])
 def test_zns_write_implicitly_open(nvme0, nvme0n1, qpair, slba, repeat):
-    css = get_cap_css(nvme0)
-    if not (css & 0x40):
+    if zns_not_supported(nvme0):
         pytest.skip("zns is not supported")
 
     buf = Buffer(96*1024)
@@ -551,20 +523,20 @@ def test_zns_write_implicitly_open(nvme0, nvme0n1, qpair, slba, repeat):
     assert z0.state == 'Empty'
     assert z0.wpointer == slba
 
-    z0.write(qpair, buf, 0, 96//4)
+    z0.write(qpair, buf, 0, 16).waitdone()
     time.sleep(1)
+    logging.info("Write pointer:0x%x" % z0.wpointer)
     assert z0.state == 'Implicitly Opened'
-    assert z0.wpointer == slba+0x18
+    assert z0.wpointer == slba+16
 
     z0.close()
     #logging.info(z0)
     assert z0.state == 'Closed'
-    assert z0.wpointer == slba+0x18
+    assert z0.wpointer == slba+0x10
     
     z0.finish()
-    qpair.waitdone()
     logging.info(z0)
     assert z0.state == 'Full'
-    assert z0.wpointer == slba+0x4800
+    assert z0.wpointer == slba+0x10
 
 


### PR DESCRIPTION
Use fixtures for zone parameters

Made some parameter changes such that all tests passed.
Log:

============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_zns_management_receive 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:06:04.839] INFO script(60): setup random seed: 0x3275a5b6
-------------------------------- live log call ---------------------------------
[2020-10-11 11:06:04.932] INFO test_zns_management_receive(152): number of zones: 8
[2020-10-11 11:06:04.939] INFO test_zns_management_receive(153): zone size: 0x8000
[2020-10-11 11:06:04.962] INFO test_zns_management_receive(165): zone slba 0x0, state Empty, capacity 0x8000, write pointer 0x0
[2020-10-11 11:06:04.966] INFO test_zns_management_receive(165): zone slba 0x8000, state Empty, capacity 0x8000, write pointer 0x8000
[2020-10-11 11:06:04.990] INFO test_zns_management_receive(165): zone slba 0x10000, state Empty, capacity 0x8000, write pointer 0x10000
[2020-10-11 11:06:04.993] INFO test_zns_management_receive(165): zone slba 0x18000, state Empty, capacity 0x8000, write pointer 0x18000
[2020-10-11 11:06:05.010] INFO test_zns_management_receive(165): zone slba 0x20000, state Empty, capacity 0x8000, write pointer 0x20000
[2020-10-11 11:06:05.012] INFO test_zns_management_receive(165): zone slba 0x28000, state Empty, capacity 0x8000, write pointer 0x28000
[2020-10-11 11:06:05.021] INFO test_zns_management_receive(165): zone slba 0x30000, state Empty, capacity 0x8000, write pointer 0x30000
[2020-10-11 11:06:05.033] INFO test_zns_management_receive(165): zone slba 0x38000, state Empty, capacity 0x8000, write pointer 0x38000
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:06:05.041] INFO script(62): test duration: 0.202 sec


-------------- generated xml file: /tmp/tmp-346110kcpYPJxWlX1.xml --------------
============================== 1 passed in 0.29s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_dut_firmware_and_model_name 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:09:17.261] INFO script(60): setup random seed: 0x3dedc82c
-------------------------------- live log call ---------------------------------
[2020-10-11 11:09:17.344] INFO test_dut_firmware_and_model_name(129): QEMU NVMe Ctrl
[2020-10-11 11:09:17.345] INFO test_dut_firmware_and_model_name(130): 1.0
[2020-10-11 11:09:17.345] INFO test_dut_firmware_and_model_name(131): testing conformance with pynvme 2.1.0
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:09:17.349] INFO script(62): test duration: 0.087 sec


-------------- generated xml file: /tmp/tmp-346112ahyt9kPytPY.xml --------------
============================== 1 passed in 0.16s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_zns_identify_namespace 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:09:24.212] INFO script(60): setup random seed: 0x3e57d6d2
-------------------------------- live log call ---------------------------------
[2020-10-11 11:09:24.292] INFO test_zns_identify_namespace(136): pynvme zns buffer
[0x00000000]  36 1b f4 1a 64 65 61 64  62 65 65 66 20 20 20 20  6...deadbeef    
[0x00000010]  20 20 20 20 20 20 20 20  51 45 4d 55 20 4e 56 4d          QEMU NVM
[0x00000020]  65 20 43 74 72 6c 20 20  20 20 20 20 20 20 20 20  e Ctrl          
[0x00000030]  20 20 20 20 20 20 20 20  20 20 20 20 20 20 20 20                  

[2020-10-11 11:09:24.294] INFO test_zns_identify_namespace(138): pynvme zns buffer
[0x00000000]  00 00 04 00 00 00 00 00  00 00 04 00 00 00 00 00  ................
[0x00000010]  00 00 04 00 00 00 00 00  04 00 00 00 00 00 00 00  ................
[0x00000020]  00 09 00 00 00 00 00 00  00 00 00 00 00 00 00 00  ................
[0x00000030]  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  ................

[2020-10-11 11:09:24.295] INFO test_zns_identify_namespace(140): pynvme zns buffer
[0x00000000]  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  ................
[0x00000010]  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  ................
[0x00000020]  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  ................
[0x00000030]  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  ................

[2020-10-11 11:09:24.296] INFO test_zns_identify_namespace(142): pynvme zns buffer
[0x00000000]  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  ................
[0x00000010]  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  ................
[0x00000020]  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  ................
[0x00000030]  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  ................

PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:09:24.300] INFO script(62): test duration: 0.088 sec


-------------- generated xml file: /tmp/tmp-34611l1JTPbEIrEpn.xml --------------
============================== 1 passed in 0.16s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_zns_management_send 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:09:28.300] INFO script(60): setup random seed: 0x3e963842
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:09:28.415] INFO script(62): test duration: 0.115 sec


-------------- generated xml file: /tmp/tmp-346116xEqVu1nnMoL.xml --------------
============================== 1 passed in 0.20s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_zns_state_machine_all 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:09:34.188] INFO script(60): setup random seed: 0x3ef00df6
-------------------------------- live log call ---------------------------------
[2020-10-11 11:09:34.279] INFO test_zns_state_machine_all(232): zslba:0x0
[2020-10-11 11:09:34.302] INFO test_zns_state_machine_all(232): zslba:0x8000
[2020-10-11 11:09:34.317] INFO test_zns_state_machine_all(232): zslba:0x10000
[2020-10-11 11:09:34.344] INFO test_zns_state_machine_all(232): zslba:0x18000
[2020-10-11 11:09:34.368] INFO test_zns_state_machine_all(232): zslba:0x20000
[2020-10-11 11:09:34.378] INFO test_zns_state_machine_all(232): zslba:0x28000
[2020-10-11 11:09:34.388] INFO test_zns_state_machine_all(232): zslba:0x30000
[2020-10-11 11:09:34.420] INFO test_zns_state_machine_all(232): zslba:0x38000
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:09:34.439] INFO script(62): test duration: 0.251 sec


-------------- generated xml file: /tmp/tmp-34611Y15iASCzeQc6.xml --------------
============================== 1 passed in 0.33s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_zns_show_zone 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:09:43.007] INFO script(60): setup random seed: 0x3f769f10
-------------------------------- live log call ---------------------------------
[2020-10-11 11:09:43.110] INFO test_zns_show_zone(281): zone slba 0x0, state Empty, capacity 0x8000, write pointer 0x0
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:09:43.131] INFO script(62): test duration: 0.125 sec


-------------- generated xml file: /tmp/tmp-34611QA0RMGCq0foU.xml --------------
============================== 1 passed in 0.20s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_zns_write_full_zone 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:09:47.153] INFO script(60): setup random seed: 0x3fb5e430
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:09:47.257] INFO script(62): test duration: 0.104 sec


-------------- generated xml file: /tmp/tmp-34611tUgAkGh388Ud.xml --------------
============================== 1 passed in 0.19s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_zns_fill_a_zone 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:10:00.533] INFO script(60): setup random seed: 0x40820e66
-------------------------------- live log call ---------------------------------
[2020-10-11 11:10:00.631] INFO test_zns_fill_a_zone(305): Test zslba: 0x18000
[2020-10-11 11:10:01.502] INFO test_zns_management_receive(152): number of zones: 8
[2020-10-11 11:10:01.503] INFO test_zns_management_receive(153): zone size: 0x8000
[2020-10-11 11:10:01.503] INFO test_zns_management_receive(165): zone slba 0x0, state Full, capacity 0x8000, write pointer 0x0
[2020-10-11 11:10:01.505] INFO test_zns_management_receive(165): zone slba 0x8000, state Empty, capacity 0x8000, write pointer 0x8000
[2020-10-11 11:10:01.511] INFO test_zns_management_receive(165): zone slba 0x10000, state Empty, capacity 0x8000, write pointer 0x10000
[2020-10-11 11:10:01.513] INFO test_zns_management_receive(165): zone slba 0x18000, state Full, capacity 0x8000, write pointer 0x20000
[2020-10-11 11:10:01.515] INFO test_zns_management_receive(165): zone slba 0x20000, state Implicitly Opened, capacity 0x8000, write pointer 0x20010
[2020-10-11 11:10:01.516] INFO test_zns_management_receive(165): zone slba 0x28000, state Empty, capacity 0x8000, write pointer 0x28000
[2020-10-11 11:10:01.519] INFO test_zns_management_receive(165): zone slba 0x30000, state Empty, capacity 0x8000, write pointer 0x30000
[2020-10-11 11:10:01.528] INFO test_zns_management_receive(165): zone slba 0x38000, state Empty, capacity 0x8000, write pointer 0x38000
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:10:01.646] INFO script(62): test duration: 1.113 sec


-------------- generated xml file: /tmp/tmp-34611cixxpqdNPj2w.xml --------------
============================== 1 passed in 1.19s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_zns_ioworker 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:10:22.329] INFO script(60): setup random seed: 0x41cea1fd
-------------------------------- live log call ---------------------------------
[2020-10-11 11:10:22.460] INFO test_zns_ioworker(325): Test zslba: 0x30000
[2020-10-11 11:10:22.465] INFO test_zns_ioworker(329): fill region with io count: 4096
[2020-10-11 11:10:23.549] INFO test_zns_management_receive(152): number of zones: 8
[2020-10-11 11:10:23.550] INFO test_zns_management_receive(153): zone size: 0x8000
[2020-10-11 11:10:23.558] INFO test_zns_management_receive(165): zone slba 0x0, state Full, capacity 0x8000, write pointer 0x0
[2020-10-11 11:10:23.563] INFO test_zns_management_receive(165): zone slba 0x8000, state Empty, capacity 0x8000, write pointer 0x8000
[2020-10-11 11:10:23.566] INFO test_zns_management_receive(165): zone slba 0x10000, state Empty, capacity 0x8000, write pointer 0x10000
[2020-10-11 11:10:23.570] INFO test_zns_management_receive(165): zone slba 0x18000, state Full, capacity 0x8000, write pointer 0x20000
[2020-10-11 11:10:23.573] INFO test_zns_management_receive(165): zone slba 0x20000, state Implicitly Opened, capacity 0x8000, write pointer 0x20010
[2020-10-11 11:10:23.579] INFO test_zns_management_receive(165): zone slba 0x28000, state Empty, capacity 0x8000, write pointer 0x28000
[2020-10-11 11:10:23.584] INFO test_zns_management_receive(165): zone slba 0x30000, state Full, capacity 0x8000, write pointer 0x38000
[2020-10-11 11:10:23.596] INFO test_zns_management_receive(165): zone slba 0x38000, state Empty, capacity 0x8000, write pointer 0x38000
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:10:23.715] INFO script(62): test duration: 1.386 sec


-------------- generated xml file: /tmp/tmp-34611t4PKqORWr5Ux.xml --------------
============================== 1 passed in 1.48s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_zns_transition_next_zone 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:10:29.463] INFO script(60): setup random seed: 0x423b7e07
-------------------------------- live log call ---------------------------------
[2020-10-11 11:10:29.567] INFO test_zns_transition_next_zone(349): Test zslba: 0x18000
[2020-10-11 11:10:29.568] INFO test_zns_transition_next_zone(350): Next zslba: 0x20000
[2020-10-11 11:10:29.602] INFO test_zns_transition_next_zone(356): fill region with io count: 4112
[2020-10-11 11:10:30.704] INFO test_zns_management_receive(152): number of zones: 8
[2020-10-11 11:10:30.705] INFO test_zns_management_receive(153): zone size: 0x8000
[2020-10-11 11:10:30.706] INFO test_zns_management_receive(165): zone slba 0x0, state Full, capacity 0x8000, write pointer 0x0
[2020-10-11 11:10:30.708] INFO test_zns_management_receive(165): zone slba 0x8000, state Empty, capacity 0x8000, write pointer 0x8000
[2020-10-11 11:10:30.711] INFO test_zns_management_receive(165): zone slba 0x10000, state Empty, capacity 0x8000, write pointer 0x10000
[2020-10-11 11:10:30.713] INFO test_zns_management_receive(165): zone slba 0x18000, state Full, capacity 0x8000, write pointer 0x20000
[2020-10-11 11:10:30.718] INFO test_zns_management_receive(165): zone slba 0x20000, state Implicitly Opened, capacity 0x8000, write pointer 0x20080
[2020-10-11 11:10:30.723] INFO test_zns_management_receive(165): zone slba 0x28000, state Empty, capacity 0x8000, write pointer 0x28000
[2020-10-11 11:10:30.730] INFO test_zns_management_receive(165): zone slba 0x30000, state Full, capacity 0x8000, write pointer 0x38000
[2020-10-11 11:10:30.735] INFO test_zns_management_receive(165): zone slba 0x38000, state Empty, capacity 0x8000, write pointer 0x38000
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:10:30.855] INFO script(62): test duration: 1.392 sec


-------------- generated xml file: /tmp/tmp-34611wxmKfUv4bRLf.xml --------------
============================== 1 passed in 1.47s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_zns_write_1 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:10:36.245] INFO script(60): setup random seed: 0x42a2fb8d
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:10:36.422] INFO script(62): test duration: 0.176 sec


-------------- generated xml file: /tmp/tmp-34611Tx9HcbvqGMdr.xml --------------
============================== 1 passed in 0.25s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_zns_write_2 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:10:42.700] INFO script(60): setup random seed: 0x4305790f
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:10:42.831] INFO script(62): test duration: 0.131 sec


-------------- generated xml file: /tmp/tmp-34611v7eHHLee0xLR.xml --------------
============================== 1 passed in 0.22s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_zns_write_192k 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:10:46.786] INFO script(60): setup random seed: 0x4343d0f4
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:10:46.936] INFO script(62): test duration: 0.150 sec


-------------- generated xml file: /tmp/tmp-34611DsYexBe3ij7w.xml --------------
============================== 1 passed in 0.24s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_zns_write_invalid_lba 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:10:51.296] INFO script(60): setup random seed: 0x4388a12d
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:10:51.407] INFO script(62): test duration: 0.112 sec


-------------- generated xml file: /tmp/tmp-34611z5nES40eVqwu.xml --------------
============================== 1 passed in 0.20s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_zns_write_twice 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:10:56.085] INFO script(60): setup random seed: 0x43d1b79a
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:10:56.211] INFO script(62): test duration: 0.125 sec


-------------- generated xml file: /tmp/tmp-34611XQmefgdbzBLe.xml --------------
============================== 1 passed in 0.20s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_zns_write_to_full 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:10:59.776] INFO script(60): setup random seed: 0x440a0756
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:00.226] INFO script(62): test duration: 0.450 sec


-------------- generated xml file: /tmp/tmp-34611HSv3Qb80h4pP.xml --------------
============================== 1 passed in 0.56s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_zns_ioworker_baisc 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:03.825] INFO script(60): setup random seed: 0x4447cf06
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:05.047] INFO test_zns_ioworker_baisc(465): {'io_count_read': 0, 'io_count_nonread': 2048, 'mseconds': 710, 'latency_max_us': 24527, 'error': 0, 'cpu_usage': 0.5366197183098591, 'latency_average_us': 4398, 'io_count_write': 2048}
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:05.164] INFO script(62): test duration: 1.339 sec


-------------- generated xml file: /tmp/tmp-3461191BhcJW2fQC8.xml --------------
============================== 1 passed in 1.41s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_zns_hello_world_2 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:08.321] INFO script(60): setup random seed: 0x448c6ba0
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:08.446] INFO script(62): test duration: 0.125 sec


-------------- generated xml file: /tmp/tmp-34611YZgUvoeNeeCm.xml --------------
============================== 1 passed in 0.21s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 5 items

scripts/conformance/07_zns/test_zns.py::test_zns_state_machine[0] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:13.303] INFO script(60): setup random seed: 0x44d86f53
PASSED                                                                   [ 20%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:13.414] INFO script(62): test duration: 0.111 sec

scripts/conformance/07_zns/test_zns.py::test_zns_state_machine[32768] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:13.431] INFO script(60): setup random seed: 0x44da6541
PASSED                                                                   [ 40%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:13.581] INFO script(62): test duration: 0.150 sec

scripts/conformance/07_zns/test_zns.py::test_zns_state_machine[65536] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:13.586] INFO script(60): setup random seed: 0x44dcc309
PASSED                                                                   [ 60%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:14.685] INFO script(62): test duration: 1.098 sec

scripts/conformance/07_zns/test_zns.py::test_zns_state_machine[98304] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:14.688] INFO script(60): setup random seed: 0x44ed935d
PASSED                                                                   [ 80%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:14.782] INFO script(62): test duration: 0.094 sec

scripts/conformance/07_zns/test_zns.py::test_zns_state_machine[229376] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:14.786] INFO script(60): setup random seed: 0x44ef1048
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:14.898] INFO script(62): test duration: 0.113 sec


=============================== warnings summary ===============================
scripts/conformance/07_zns/test_zns.py::test_zns_state_machine[65536]
  /home/ygao/pynvme/conftest.py:79: UserWarning: init namespaces first warning
    ret = d.Controller(pcie)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
-------------- generated xml file: /tmp/tmp-34611dY1tS4Kn2t5e.xml --------------
========================= 5 passed, 1 warning in 1.68s =========================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 6 items

scripts/conformance/07_zns/test_zns.py::test_zns_write_and_read_multiple[1] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:19.329] INFO script(60): setup random seed: 0x45346113
PASSED                                                                   [ 16%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:19.459] INFO script(62): test duration: 0.130 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_and_read_multiple[2] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:19.462] INFO script(60): setup random seed: 0x45366a66
PASSED                                                                   [ 33%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:19.602] INFO script(62): test duration: 0.140 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_and_read_multiple[10] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:19.605] INFO script(60): setup random seed: 0x453898f0
PASSED                                                                   [ 50%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:19.753] INFO script(62): test duration: 0.148 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_and_read_multiple[39] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:19.756] INFO script(60): setup random seed: 0x453ae4f4
PASSED                                                                   [ 66%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:19.886] INFO script(62): test duration: 0.131 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_and_read_multiple[100] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:19.889] INFO script(60): setup random seed: 0x453ceff8
PASSED                                                                   [ 83%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:20.129] INFO script(62): test duration: 0.240 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_and_read_multiple[255] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:20.132] INFO script(60): setup random seed: 0x4540a4d1
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:20.476] INFO script(62): test duration: 0.344 sec


-------------- generated xml file: /tmp/tmp-3461165Q5nwnpj6AE.xml --------------
============================== 6 passed in 1.22s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 3 items

scripts/conformance/07_zns/test_zns.py::test_zns_write_explicitly_open[0] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:24.124] INFO script(60): setup random seed: 0x457d8be7
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:25.232] INFO test_zns_write_explicitly_open(507): zone slba 0x38000, state Full, capacity 0x8000, write pointer 0x38010
PASSED                                                                   [ 33%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:25.259] INFO script(62): test duration: 1.135 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_explicitly_open[1] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:25.265] INFO script(60): setup random seed: 0x458ef6dc
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:26.331] INFO test_zns_write_explicitly_open(507): zone slba 0x38000, state Full, capacity 0x8000, write pointer 0x38010
PASSED                                                                   [ 66%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:26.363] INFO script(62): test duration: 1.098 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_explicitly_open[2] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:26.367] INFO script(60): setup random seed: 0x459fc7c3
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:27.454] INFO test_zns_write_explicitly_open(507): zone slba 0x20000, state Full, capacity 0x8000, write pointer 0x20010
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:27.469] INFO script(62): test duration: 1.101 sec


-------------- generated xml file: /tmp/tmp-34611xyrJceS3K0fr.xml --------------
============================== 3 passed in 3.42s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 30 items

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[0-0] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:32.383] INFO script(60): setup random seed: 0x45fb92db
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:33.476] INFO test_zns_write_implicitly_open(528): Write pointer:0x10
[2020-10-11 11:11:33.491] INFO test_zns_write_implicitly_open(538): zone slba 0x0, state Full, capacity 0x8000, write pointer 0x10
PASSED                                                                   [  3%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:33.507] INFO script(62): test duration: 1.124 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[0-1] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:33.512] INFO script(60): setup random seed: 0x460ccb3e
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:34.589] INFO test_zns_write_implicitly_open(528): Write pointer:0x10
[2020-10-11 11:11:34.603] INFO test_zns_write_implicitly_open(538): zone slba 0x0, state Full, capacity 0x8000, write pointer 0x10
PASSED                                                                   [  6%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:34.615] INFO script(62): test duration: 1.103 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[0-2] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:34.618] INFO script(60): setup random seed: 0x461dab96
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:35.708] INFO test_zns_write_implicitly_open(528): Write pointer:0x10
[2020-10-11 11:11:35.710] INFO test_zns_write_implicitly_open(538): zone slba 0x0, state Full, capacity 0x8000, write pointer 0x10
PASSED                                                                   [ 10%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:35.718] INFO script(62): test duration: 1.101 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[0-3] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:35.722] INFO script(60): setup random seed: 0x462e848f
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:36.791] INFO test_zns_write_implicitly_open(528): Write pointer:0x10
[2020-10-11 11:11:36.793] INFO test_zns_write_implicitly_open(538): zone slba 0x0, state Full, capacity 0x8000, write pointer 0x10
PASSED                                                                   [ 13%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:36.801] INFO script(62): test duration: 1.080 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[0-4] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:36.806] INFO script(60): setup random seed: 0x463f107e
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:37.883] INFO test_zns_write_implicitly_open(528): Write pointer:0x10
[2020-10-11 11:11:37.897] INFO test_zns_write_implicitly_open(538): zone slba 0x0, state Full, capacity 0x8000, write pointer 0x10
PASSED                                                                   [ 16%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:37.913] INFO script(62): test duration: 1.107 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[0-5] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:37.916] INFO script(60): setup random seed: 0x465001ba
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:38.982] INFO test_zns_write_implicitly_open(528): Write pointer:0x10
[2020-10-11 11:11:38.991] INFO test_zns_write_implicitly_open(538): zone slba 0x0, state Full, capacity 0x8000, write pointer 0x10
PASSED                                                                   [ 20%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:39.006] INFO script(62): test duration: 1.090 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[0-6] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:39.009] INFO script(60): setup random seed: 0x4660ad73
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:40.083] INFO test_zns_write_implicitly_open(528): Write pointer:0x10
[2020-10-11 11:11:40.094] INFO test_zns_write_implicitly_open(538): zone slba 0x0, state Full, capacity 0x8000, write pointer 0x10
PASSED                                                                   [ 23%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:40.103] INFO script(62): test duration: 1.094 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[0-7] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:40.107] INFO script(60): setup random seed: 0x46716d9f
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:41.180] INFO test_zns_write_implicitly_open(528): Write pointer:0x10
[2020-10-11 11:11:41.184] INFO test_zns_write_implicitly_open(538): zone slba 0x0, state Full, capacity 0x8000, write pointer 0x10
PASSED                                                                   [ 26%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:41.191] INFO script(62): test duration: 1.084 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[0-8] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:41.196] INFO script(60): setup random seed: 0x46820b17
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:42.278] INFO test_zns_write_implicitly_open(528): Write pointer:0x10
[2020-10-11 11:11:42.283] INFO test_zns_write_implicitly_open(538): zone slba 0x0, state Full, capacity 0x8000, write pointer 0x10
PASSED                                                                   [ 30%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:42.304] INFO script(62): test duration: 1.108 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[0-9] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:42.307] INFO script(60): setup random seed: 0x4693010f
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:43.385] INFO test_zns_write_implicitly_open(528): Write pointer:0x10
[2020-10-11 11:11:43.389] INFO test_zns_write_implicitly_open(538): zone slba 0x0, state Full, capacity 0x8000, write pointer 0x10
PASSED                                                                   [ 33%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:43.402] INFO script(62): test duration: 1.095 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[32768-0] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:43.405] INFO script(60): setup random seed: 0x46a3c363
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:45.492] INFO test_zns_write_implicitly_open(528): Write pointer:0x8010
[2020-10-11 11:11:45.499] INFO test_zns_write_implicitly_open(538): zone slba 0x8000, state Full, capacity 0x8000, write pointer 0x8010
PASSED                                                                   [ 36%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:45.516] INFO script(62): test duration: 2.110 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[32768-1] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:45.519] INFO script(60): setup random seed: 0x46c4031d
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:46.605] INFO test_zns_write_implicitly_open(528): Write pointer:0x8010
[2020-10-11 11:11:46.619] INFO test_zns_write_implicitly_open(538): zone slba 0x8000, state Full, capacity 0x8000, write pointer 0x8010
PASSED                                                                   [ 40%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:46.629] INFO script(62): test duration: 1.110 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[32768-2] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:46.633] INFO script(60): setup random seed: 0x46d50488
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:47.718] INFO test_zns_write_implicitly_open(528): Write pointer:0x8010
[2020-10-11 11:11:47.721] INFO test_zns_write_implicitly_open(538): zone slba 0x8000, state Full, capacity 0x8000, write pointer 0x8010
PASSED                                                                   [ 43%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:47.742] INFO script(62): test duration: 1.108 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[32768-3] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:47.746] INFO script(60): setup random seed: 0x46e5fc99
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:48.818] INFO test_zns_write_implicitly_open(528): Write pointer:0x8010
[2020-10-11 11:11:48.825] INFO test_zns_write_implicitly_open(538): zone slba 0x8000, state Full, capacity 0x8000, write pointer 0x8010
PASSED                                                                   [ 46%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:48.838] INFO script(62): test duration: 1.093 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[32768-4] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:48.842] INFO script(60): setup random seed: 0x46f6b953
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:49.916] INFO test_zns_write_implicitly_open(528): Write pointer:0x8010
[2020-10-11 11:11:49.924] INFO test_zns_write_implicitly_open(538): zone slba 0x8000, state Full, capacity 0x8000, write pointer 0x8010
PASSED                                                                   [ 50%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:49.942] INFO script(62): test duration: 1.100 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[32768-5] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:49.946] INFO script(60): setup random seed: 0x47078f7e
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:51.033] INFO test_zns_write_implicitly_open(528): Write pointer:0x8010
[2020-10-11 11:11:51.036] INFO test_zns_write_implicitly_open(538): zone slba 0x8000, state Full, capacity 0x8000, write pointer 0x8010
PASSED                                                                   [ 53%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:51.045] INFO script(62): test duration: 1.100 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[32768-6] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:51.049] INFO script(60): setup random seed: 0x47186435
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:52.128] INFO test_zns_write_implicitly_open(528): Write pointer:0x8010
[2020-10-11 11:11:52.137] INFO test_zns_write_implicitly_open(538): zone slba 0x8000, state Full, capacity 0x8000, write pointer 0x8010
PASSED                                                                   [ 56%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:52.155] INFO script(62): test duration: 1.106 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[32768-7] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:52.159] INFO script(60): setup random seed: 0x47295564
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:53.227] INFO test_zns_write_implicitly_open(528): Write pointer:0x8010
[2020-10-11 11:11:53.240] INFO test_zns_write_implicitly_open(538): zone slba 0x8000, state Full, capacity 0x8000, write pointer 0x8010
PASSED                                                                   [ 60%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:53.252] INFO script(62): test duration: 1.092 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[32768-8] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:53.256] INFO script(60): setup random seed: 0x473a102c
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:54.326] INFO test_zns_write_implicitly_open(528): Write pointer:0x8010
[2020-10-11 11:11:54.329] INFO test_zns_write_implicitly_open(538): zone slba 0x8000, state Full, capacity 0x8000, write pointer 0x8010
PASSED                                                                   [ 63%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:54.347] INFO script(62): test duration: 1.092 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[32768-9] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:54.351] INFO script(60): setup random seed: 0x474ac865
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:55.425] INFO test_zns_write_implicitly_open(528): Write pointer:0x8010
[2020-10-11 11:11:55.439] INFO test_zns_write_implicitly_open(538): zone slba 0x8000, state Full, capacity 0x8000, write pointer 0x8010
PASSED                                                                   [ 66%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:55.454] INFO script(62): test duration: 1.103 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[229376-0] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:55.459] INFO script(60): setup random seed: 0x475baf03
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:56.544] INFO test_zns_write_implicitly_open(528): Write pointer:0x38010
[2020-10-11 11:11:56.547] INFO test_zns_write_implicitly_open(538): zone slba 0x38000, state Full, capacity 0x8000, write pointer 0x38010
PASSED                                                                   [ 70%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:56.559] INFO script(62): test duration: 1.100 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[229376-1] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:56.562] INFO script(60): setup random seed: 0x476c826d
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:57.631] INFO test_zns_write_implicitly_open(528): Write pointer:0x38010
[2020-10-11 11:11:57.643] INFO test_zns_write_implicitly_open(538): zone slba 0x38000, state Full, capacity 0x8000, write pointer 0x38010
PASSED                                                                   [ 73%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:57.651] INFO script(62): test duration: 1.090 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[229376-2] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:57.658] INFO script(60): setup random seed: 0x477d3bb3
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:58.746] INFO test_zns_write_implicitly_open(528): Write pointer:0x38010
[2020-10-11 11:11:58.759] INFO test_zns_write_implicitly_open(538): zone slba 0x38000, state Full, capacity 0x8000, write pointer 0x38010
PASSED                                                                   [ 76%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:58.783] INFO script(62): test duration: 1.125 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[229376-3] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:58.786] INFO script(60): setup random seed: 0x478e7527
-------------------------------- live log call ---------------------------------
[2020-10-11 11:11:59.854] INFO test_zns_write_implicitly_open(528): Write pointer:0x38010
[2020-10-11 11:11:59.859] INFO test_zns_write_implicitly_open(538): zone slba 0x38000, state Full, capacity 0x8000, write pointer 0x38010
PASSED                                                                   [ 80%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:11:59.869] INFO script(62): test duration: 1.083 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[229376-4] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:11:59.872] INFO script(60): setup random seed: 0x479f073c
-------------------------------- live log call ---------------------------------
[2020-10-11 11:12:00.946] INFO test_zns_write_implicitly_open(528): Write pointer:0x38010
[2020-10-11 11:12:00.949] INFO test_zns_write_implicitly_open(538): zone slba 0x38000, state Full, capacity 0x8000, write pointer 0x38010
PASSED                                                                   [ 83%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:12:00.965] INFO script(62): test duration: 1.092 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[229376-5] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:12:00.968] INFO script(60): setup random seed: 0x47afbfdf
-------------------------------- live log call ---------------------------------
[2020-10-11 11:12:03.050] INFO test_zns_write_implicitly_open(528): Write pointer:0x38010
[2020-10-11 11:12:03.052] INFO test_zns_write_implicitly_open(538): zone slba 0x38000, state Full, capacity 0x8000, write pointer 0x38010
PASSED                                                                   [ 86%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:12:03.069] INFO script(62): test duration: 2.100 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[229376-6] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:12:03.072] INFO script(60): setup random seed: 0x47cfd940
-------------------------------- live log call ---------------------------------
[2020-10-11 11:12:04.144] INFO test_zns_write_implicitly_open(528): Write pointer:0x38010
[2020-10-11 11:12:04.168] INFO test_zns_write_implicitly_open(538): zone slba 0x38000, state Full, capacity 0x8000, write pointer 0x38010
PASSED                                                                   [ 90%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:12:04.188] INFO script(62): test duration: 1.116 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[229376-7] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:12:04.192] INFO script(60): setup random seed: 0x47e0f1a8
-------------------------------- live log call ---------------------------------
[2020-10-11 11:12:05.258] INFO test_zns_write_implicitly_open(528): Write pointer:0x38010
[2020-10-11 11:12:05.263] INFO test_zns_write_implicitly_open(538): zone slba 0x38000, state Full, capacity 0x8000, write pointer 0x38010
PASSED                                                                   [ 93%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:12:05.284] INFO script(62): test duration: 1.092 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[229376-8] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:12:05.287] INFO script(60): setup random seed: 0x47f1a4ca
-------------------------------- live log call ---------------------------------
[2020-10-11 11:12:06.352] INFO test_zns_write_implicitly_open(528): Write pointer:0x38010
[2020-10-11 11:12:06.356] INFO test_zns_write_implicitly_open(538): zone slba 0x38000, state Full, capacity 0x8000, write pointer 0x38010
PASSED                                                                   [ 96%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:12:06.371] INFO script(62): test duration: 1.085 sec

scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[229376-9] 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:12:06.375] INFO script(60): setup random seed: 0x48024012
-------------------------------- live log call ---------------------------------
[2020-10-11 11:12:07.447] INFO test_zns_write_implicitly_open(528): Write pointer:0x38010
[2020-10-11 11:12:07.449] INFO test_zns_write_implicitly_open(538): zone slba 0x38000, state Full, capacity 0x8000, write pointer 0x38010
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:12:07.474] INFO script(62): test duration: 1.099 sec


=============================== warnings summary ===============================
scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[32768-0]
scripts/conformance/07_zns/test_zns.py::test_zns_write_implicitly_open[229376-5]
  /home/ygao/pynvme/conftest.py:79: UserWarning: init namespaces first warning
    ret = d.Controller(pcie)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
-------------- generated xml file: /tmp/tmp-34611j1EdtCknPh6Q.xml --------------
======================= 30 passed, 2 warnings in 35.17s ========================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_zns_management_receive 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:12:22.570] INFO script(60): setup random seed: 0x48f95eb2
-------------------------------- live log call ---------------------------------
[2020-10-11 11:12:22.686] INFO test_zns_management_receive(152): number of zones: 8
[2020-10-11 11:12:22.686] INFO test_zns_management_receive(153): zone size: 0x8000
[2020-10-11 11:12:22.695] INFO test_zns_management_receive(165): zone slba 0x0, state Full, capacity 0x8000, write pointer 0x10
[2020-10-11 11:12:22.720] INFO test_zns_management_receive(165): zone slba 0x8000, state Full, capacity 0x8000, write pointer 0x8010
[2020-10-11 11:12:22.722] INFO test_zns_management_receive(165): zone slba 0x10000, state Empty, capacity 0x8000, write pointer 0x10000
[2020-10-11 11:12:22.725] INFO test_zns_management_receive(165): zone slba 0x18000, state Full, capacity 0x8000, write pointer 0x18640
[2020-10-11 11:12:22.727] INFO test_zns_management_receive(165): zone slba 0x20000, state Full, capacity 0x8000, write pointer 0x20010
[2020-10-11 11:12:22.729] INFO test_zns_management_receive(165): zone slba 0x28000, state Full, capacity 0x8000, write pointer 0x28020
[2020-10-11 11:12:22.732] INFO test_zns_management_receive(165): zone slba 0x30000, state Full, capacity 0x8000, write pointer 0x38000
[2020-10-11 11:12:22.736] INFO test_zns_management_receive(165): zone slba 0x38000, state Full, capacity 0x8000, write pointer 0x38010
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:12:22.769] INFO script(62): test duration: 0.199 sec


-------------- generated xml file: /tmp/tmp-34611p6wpdSLMT1aT.xml --------------
============================== 1 passed in 0.28s ===============================
============================= test session starts ==============================
platform linux -- Python 3.8.5, pytest-6.0.2, py-1.9.0, pluggy-0.13.1
rootdir: /home/ygao/pynvme, configfile: pytest.ini
plugins: cov-2.10.1, excel-1.4.1
collected 1 item

scripts/conformance/07_zns/test_zns.py::test_reset_all_zones 
-------------------------------- live log setup --------------------------------
[2020-10-11 11:12:29.773] INFO script(60): setup random seed: 0x4967449b
-------------------------------- live log call ---------------------------------
[2020-10-11 11:12:29.872] INFO test_reset_all_zones(121): Reset zone @zslba: 0x0
[2020-10-11 11:12:29.874] INFO test_reset_all_zones(121): Reset zone @zslba: 0x8000
[2020-10-11 11:12:29.892] INFO test_reset_all_zones(121): Reset zone @zslba: 0x10000
[2020-10-11 11:12:29.898] INFO test_reset_all_zones(121): Reset zone @zslba: 0x18000
[2020-10-11 11:12:29.911] INFO test_reset_all_zones(121): Reset zone @zslba: 0x20000
[2020-10-11 11:12:29.917] INFO test_reset_all_zones(121): Reset zone @zslba: 0x28000
[2020-10-11 11:12:29.919] INFO test_reset_all_zones(121): Reset zone @zslba: 0x30000
[2020-10-11 11:12:29.957] INFO test_reset_all_zones(121): Reset zone @zslba: 0x38000
[2020-10-11 11:12:29.961] INFO test_zns_management_receive(152): number of zones: 8
[2020-10-11 11:12:29.962] INFO test_zns_management_receive(153): zone size: 0x8000
[2020-10-11 11:12:29.964] INFO test_zns_management_receive(165): zone slba 0x0, state Empty, capacity 0x8000, write pointer 0x0
[2020-10-11 11:12:29.967] INFO test_zns_management_receive(165): zone slba 0x8000, state Empty, capacity 0x8000, write pointer 0x8000
[2020-10-11 11:12:29.973] INFO test_zns_management_receive(165): zone slba 0x10000, state Empty, capacity 0x8000, write pointer 0x10000
[2020-10-11 11:12:29.975] INFO test_zns_management_receive(165): zone slba 0x18000, state Empty, capacity 0x8000, write pointer 0x18000
[2020-10-11 11:12:29.978] INFO test_zns_management_receive(165): zone slba 0x20000, state Empty, capacity 0x8000, write pointer 0x20000
[2020-10-11 11:12:29.980] INFO test_zns_management_receive(165): zone slba 0x28000, state Empty, capacity 0x8000, write pointer 0x28000
[2020-10-11 11:12:29.982] INFO test_zns_management_receive(165): zone slba 0x30000, state Empty, capacity 0x8000, write pointer 0x30000
[2020-10-11 11:12:29.984] INFO test_zns_management_receive(165): zone slba 0x38000, state Empty, capacity 0x8000, write pointer 0x38000
PASSED                                                                   [100%]
------------------------------ live log teardown -------------------------------
[2020-10-11 11:12:29.991] INFO script(62): test duration: 0.219 sec


-------------- generated xml file: /tmp/tmp-346114gc8kElgCXGV.xml --------------
============================== 1 passed in 0.30s ===============================
