### PR TITLE
Use default slba for zone append, remove raw command mode

### DIFF
--- a/07_zns/test_zns.py
+++ b/07_zns/test_zns.py
@@ -508,21 +508,6 @@ def test_zns_write_implicitly_open(nvme0, nvme0n1, qpair, slba, repeat):
     assert z0.wpointer == slba+0x10
 
 
-def test_write_append(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones):
-    zone_index = int(random.randrange(num_of_zones))
-    slba = zone_size * zone_index
-    zone = Zone(qpair, nvme0n1, slba)
-    logging.info("Append Zone 0x%x, zslba: 0x%x, wp:0x%x" % (zone_index, slba, zone.wpointer))
-    zone.reset()
-    nvme0n1.send_cmd(0x7d, qpair, buf, 1, slba&0xffffffff, slba>>32).waitdone()
-    logging.info("Append Zone 0x%x, zslba: 0x%x, wp:0x%x" % (zone_index, slba, zone.wpointer))
-    nvme0n1.send_cmd(0x7d, qpair, buf, 1, slba&0xffffffff, slba>>32).waitdone()
-    logging.info("Append Zone 0x%x, zslba: 0x%x, wp:0x%x" % (zone_index, slba, zone.wpointer))
-    # zone append not from the zslba,Invalid Field in Command 00/02 (no warn in emulated drive yet)
-    # with pytest.warns(UserWarning, match="ERROR status: 00/02"):
-    nvme0n1.send_cmd(0x7d, qpair, buf, 1, slba&0xffffffff+10, slba>>32).waitdone()
-
-
 def test_zone_append(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones):
     zone_index = int(random.randrange(num_of_zones))
     slba = zone_size * zone_index
@@ -530,14 +515,14 @@ def test_zone_append(nvme0, nvme0n1, qpair, buf, zone_size, num_of_zones):
     logging.info("Append Zone 0x%x, zslba: 0x%x, wp:0x%x" % (zone_index, slba, zone.wpointer))
     zone.reset()
 
-    zone.append(qpair, buf, slba).waitdone()
+    zone.append(qpair, buf).waitdone()
     logging.info("Append Zone 0x%x, zslba: 0x%x, wp:0x%x" % (zone_index, slba, zone.wpointer))
 
-    zone.append(qpair, buf, slba).waitdone()
+    zone.append(qpair, buf).waitdone()
     logging.info("Append Zone 0x%x, zslba: 0x%x, wp:0x%x" % (zone_index, slba, zone.wpointer))
-    # zone append not from the zslba,Invalid Field in Command 00/02 (no warn in emulated drive yet)
-    # with pytest.warns(UserWarning, match="ERROR status: 00/02"):
-    zone.append(qpair, buf, slba+10).waitdone()
+    # zone append not from the zslba,Invalid Field in Command 00/02
+    with pytest.warns(UserWarning, match="ERROR status: 00/02"):
+        zone.append(qpair, buf, slba+10).waitdone()
 
     # I/O Command Set Profile (Feature Identifier 19h)
 def test_iocmd_set_profile(nvme0, nvme0n1, qpair, buf):


### PR DESCRIPTION
Use default slba for zone append in normal zone append commands, use an offset from zslba for zone append command to capture the 00/02 error. 

Remove raw command mode as we have the zone append command.